### PR TITLE
Fix SSH agent forwarding issue

### DIFF
--- a/Formula/docker-compose-oroplatform.rb
+++ b/Formula/docker-compose-oroplatform.rb
@@ -2,9 +2,8 @@ class DockerComposeOroplatform < Formula
   desc "CLI tool to run ORO applications locally or on a server"
   homepage "https://github.com/digitalspacestdio/homebrew-docker-compose-oroplatform"
   url "file:///dev/null"
-  version "0.8.3"
+  version "0.8.4"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-  revision 1
 
   def self.aliases
     ["orodc"]

--- a/bin/orodc
+++ b/bin/orodc
@@ -753,8 +753,8 @@ if [[ "${DC_ORO_MODE}" == "mutagen" ]] || [[ "${DC_ORO_MODE}" == "ssh" ]]; then
       bash -c "${DOCKER_COMPOSE_BIN_CMD} up -d ssh"
       SSH_HOST=${DC_ORO_SSH_BIND_HOST:-127.0.0.1}
       SSH_PORT=$(${DOCKER_BIN} inspect $(${DOCKER_COMPOSE_BIN_CMD} ps | grep ssh | awk '{ print $1 }') | jq -r '.[0].NetworkSettings.Ports["22/tcp"][0].HostPort')
-      if [[ 0 -eq $(ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i "${DC_ORO_CONFIG_DIR}/ssh_id_ed25519" -p ${SSH_PORT} ${ORO_DC_SSH_ARGS} ${DC_ORO_USER_NAME}@${SSH_HOST} sh -c 'ls "'${DC_ORO_APPDIR}'/"' | wc -l) ]]; then
-        until ${RSYNC_BIN} --exclude var/cache --exclude vendor --exclude node_modules --links -e "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${DC_ORO_CONFIG_DIR}/ssh_id_ed25519 -p ${SSH_PORT} ${ORO_DC_SSH_ARGS}" --timeout=3 --info=progress2 -r "${DC_ORO_APPDIR}/" ${DC_ORO_USER_NAME}@${SSH_HOST}:"${DC_ORO_APPDIR}/" 2> /dev/null; do
+      if [[ 0 -eq $(ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o 'ForwardAgent no' -o IdentitiesOnly=yes -i "${DC_ORO_CONFIG_DIR}/ssh_id_ed25519" -p ${SSH_PORT} ${ORO_DC_SSH_ARGS} ${DC_ORO_USER_NAME}@${SSH_HOST} sh -c 'ls "'${DC_ORO_APPDIR}'/"' | wc -l) ]]; then
+        until ${RSYNC_BIN} --exclude var/cache --exclude vendor --exclude node_modules --links -e "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o 'ForwardAgent no' -o IdentitiesOnly=yes -i ${DC_ORO_CONFIG_DIR}/ssh_id_ed25519 -p ${SSH_PORT} ${ORO_DC_SSH_ARGS}" --timeout=3 --info=progress2 -r "${DC_ORO_APPDIR}/" ${DC_ORO_USER_NAME}@${SSH_HOST}:"${DC_ORO_APPDIR}/" 2> /dev/null; do
           echo -n ".";
           sleep 3
         done
@@ -1047,6 +1047,8 @@ if [ $# -eq 0 ] || [ "${args[0]}" = "ssh" ]; then
     -o SendEnv=COMPOSER_AUTH \
     -o UserKnownHostsFile=/dev/null \
     -o StrictHostKeyChecking=no \
+    -o 'ForwardAgent no' \
+    -o IdentitiesOnly=yes \
     -i "${DC_ORO_CONFIG_DIR}/ssh_id_ed25519" \
     -p "${SSH_PORT}" \
     ${ORO_DC_SSH_ARGS} \

--- a/bin/orodc-sync
+++ b/bin/orodc-sync
@@ -1919,7 +1919,9 @@ function PreInit {
 
 	## Ignore SSH known host verification
 	if [ "$SSH_IGNORE_KNOWN_HOSTS" == true ]; then
-		SSH_OPTS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+		SSH_OPTS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o 'ForwardAgent no' -o IdentitiesOnly=yes"
+	else
+		SSH_OPTS="-o 'ForwardAgent no' -o IdentitiesOnly=yes"
 	fi
 
 	## SSH ControlMaster Multiplexing


### PR DESCRIPTION
- Add -o 'ForwardAgent no' to all SSH commands to prevent SSH agent forwarding
- Add -o IdentitiesOnly=yes to all SSH commands to use only specified keys
- This fixes 'Too many authentication failures' error when SSH agent is enabled
- Bump version to 0.8.4