### PR TITLE
fix: Correct PHP version detection for Oro Platform versions

### DIFF
--- a/.github/workflows/test-oro-installations.yml
+++ b/.github/workflows/test-oro-installations.yml
@@ -27,9 +27,6 @@ jobs:
       max-parallel: 1  # Run jobs sequentially to avoid conflicts
       matrix:
         include:
-          - application: marello
-            version: 4.2.0
-            repo_url: https://github.com/marellocommerce/marello.git
           - application: orocrm
             version: 6.1.4
             repo_url: https://github.com/oroinc/crm-application.git
@@ -39,6 +36,9 @@ jobs:
           - application: orocommerce
             version: 6.1.4
             repo_url: https://github.com/oroinc/orocommerce-application.git
+          - application: marello
+            version: 4.2.0
+            repo_url: https://github.com/marellocommerce/marello.git
     timeout-minutes: 60
     name: Test ${{ matrix.application }} (${{ matrix.version }})
     

--- a/bin/orodc
+++ b/bin/orodc
@@ -752,13 +752,18 @@ detect_php_version_from_composer() {
       # Extract Oro version (e.g., "6.0.*" -> "6.0", "^6.1" -> "6.1")
       local oro_version=$(echo "$oro_platform" | sed -E 's/[^0-9.]*([0-9]+\.[0-9]+).*/\1/')
       case "$oro_version" in
-        "6.1"|"6.2") echo "8.3" && return 0 ;;
-        "6.0") echo "8.2" && return 0 ;;
+        "6.0") echo "8.3" && return 0 ;;
         "5.1") echo "8.1" && return 0 ;;
-        "5.0") echo "8.0" && return 0 ;;
+        "5.0") echo "8.1" && return 0 ;;
         "4.2") echo "8.1" && return 0 ;;
-        "4.1") echo "8.0" && return 0 ;;
+        "4.1") echo "8.1" && return 0 ;;
         "4.0") echo "7.4" && return 0 ;;
+        *) 
+          # For versions >= 6.1, use PHP 8.4
+          if [[ "$oro_version" > "6.0" ]]; then
+            echo "8.4" && return 0
+          fi
+          ;;
       esac
     fi
   fi
@@ -774,7 +779,6 @@ get_compatible_node_version() {
     "8.3") echo "20" ;;
     "8.2") echo "20" ;;
     "8.1") echo "18" ;;
-    "8.0") echo "18" ;;
     "7.4") echo "16" ;;
     *) echo "20" ;;  # Default to Node 20 for unknown PHP versions
   esac


### PR DESCRIPTION
- Oro Platform 6.0 → PHP 8.3 (for Marello Commerce)
- Oro Platform >= 6.1 → PHP 8.4 (for OroCRM/OroCommerce 6.1+)
- Move Marello to end of test matrix in GitHub Actions
- Remove PHP 8.0 support, keep PHP 8.2 available