### PR TITLE
Fix Oro version detection and update defaults to PHP 8.4 / Node.js 22

### DIFF
--- a/bin/orodc
+++ b/bin/orodc
@@ -749,22 +749,34 @@ detect_php_version_from_composer() {
     # Fallback: detect from Oro Platform version
     local oro_platform=$(jq -r '.require["oro/platform"] // empty' "$DC_ORO_APPDIR/composer.json" 2>/dev/null)
     if [[ -n "$oro_platform" ]]; then
-      # Extract Oro version (e.g., "6.0.*" -> "6.0", "^6.1" -> "6.1")
-      local oro_version=$(echo "$oro_platform" | sed -E 's/[^0-9.]*([0-9]+\.[0-9]+).*/\1/')
-      case "$oro_version" in
-        "6.0") echo "8.3" && return 0 ;;
-        "5.1") echo "8.1" && return 0 ;;
-        "5.0") echo "8.1" && return 0 ;;
-        "4.2") echo "8.1" && return 0 ;;
-        "4.1") echo "8.1" && return 0 ;;
-        "4.0") echo "7.4" && return 0 ;;
-        *) 
-          # For versions >= 6.1, use PHP 8.4
-          if [[ "$oro_version" > "6.0" ]]; then
-            echo "8.4" && return 0
-          fi
-          ;;
-      esac
+      # Extract full Oro version (e.g., "6.0.8", "^6.1.0" -> "6.1.0")
+      local oro_version=$(echo "$oro_platform" | sed -E 's/[^0-9.]*([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+      # If no patch version found, try major.minor
+      if [[ ! "$oro_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        oro_version=$(echo "$oro_platform" | sed -E 's/[^0-9.]*([0-9]+\.[0-9]+).*/\1/')
+      fi
+      
+      # Convert to comparable format and determine PHP version
+      local major=$(echo "$oro_version" | cut -d. -f1)
+      local minor=$(echo "$oro_version" | cut -d. -f2)
+      local patch=$(echo "$oro_version" | cut -d. -f3 2>/dev/null || echo "0")
+      
+      # Version comparison logic
+      if [[ $major -eq 6 && $minor -eq 0 ]]; then
+        echo "8.3" && return 0  # Oro 6.0.x uses PHP 8.3
+      elif [[ $major -eq 6 && $minor -ge 1 ]] || [[ $major -gt 6 ]]; then
+        echo "8.4" && return 0  # Oro 6.1+ uses PHP 8.4
+      elif [[ $major -eq 5 && $minor -eq 1 ]]; then
+        echo "8.1" && return 0
+      elif [[ $major -eq 5 && $minor -eq 0 ]]; then
+        echo "8.1" && return 0
+      elif [[ $major -eq 4 && $minor -eq 2 ]]; then
+        echo "8.1" && return 0
+      elif [[ $major -eq 4 && $minor -eq 1 ]]; then
+        echo "8.1" && return 0
+      elif [[ $major -eq 4 && $minor -eq 0 ]]; then
+        echo "7.4" && return 0
+      fi
     fi
   fi
   return 1
@@ -780,7 +792,7 @@ get_compatible_node_version() {
     "8.2") echo "20" ;;
     "8.1") echo "18" ;;
     "7.4") echo "16" ;;
-    *) echo "20" ;;  # Default to Node 20 for unknown PHP versions
+    *) echo "22" ;;  # Default to Node 22 for unknown PHP versions
   esac
 }
 

--- a/compose/docker-compose-test.yml
+++ b/compose/docker-compose-test.yml
@@ -1,15 +1,15 @@
 services:
   test-fpm:
-    container_name: "${DC_ORO_NAME:-unnamed}_test_fpm_${DC_ORO_PHP_VERSION:-8.3}-${DC_ORO_NODE_VERSION:-20}-${DC_ORO_COMPOSER_VERSION:-2}"
+    container_name: "${DC_ORO_NAME:-unnamed}_test_fpm_${DC_ORO_PHP_VERSION:-8.4}-${DC_ORO_NODE_VERSION:-22}-${DC_ORO_COMPOSER_VERSION:-2}"
     hostname: test-fpm.${DC_ORO_NAME:-unnamed}.docker.local
-    image: ghcr.io/digitalspacestdio/orodc-php-node-symfony:${DC_ORO_PHP_VERSION:-8.3}-${DC_ORO_NODE_VERSION:-20}-${DC_ORO_COMPOSER_VERSION:-2}-${DC_ORO_PHP_DIST:-alpine}
+    image: ghcr.io/digitalspacestdio/orodc-php-node-symfony:${DC_ORO_PHP_VERSION:-8.4}-${DC_ORO_NODE_VERSION:-22}-${DC_ORO_COMPOSER_VERSION:-2}-${DC_ORO_PHP_DIST:-alpine}
     build:
-      dockerfile: Dockerfile.${DC_ORO_PHP_VERSION:-8.3}.${DC_ORO_PHP_DIST:-alpine}
+      dockerfile: Dockerfile.${DC_ORO_PHP_VERSION:-8.4}.${DC_ORO_PHP_DIST:-alpine}
       context: "${DC_ORO_CONFIG_DIR:-.}/docker/php-node-symfony"
       args:
         APP_DIR: "${DC_ORO_APPDIR:-/var/www}"
-        PHP_VERSION: "${DC_ORO_PHP_VERSION:-8.3}"
-        NODE_VERSION: "${DC_ORO_NODE_VERSION:-20}"
+        PHP_VERSION: "${DC_ORO_PHP_VERSION:-8.4}"
+        NODE_VERSION: "${DC_ORO_NODE_VERSION:-22}"
         PHP_USER_NAME: "${DC_ORO_PHP_USER_NAME:-developer}"
         PHP_USER_GROUP: "${DC_ORO_PHP_USER_GROUP:-developer}"
         PHP_UID: "${DC_ORO_PHP_UID:-1000}"
@@ -122,9 +122,9 @@ services:
         max-size: "10m"
 
   test-cli:
-    container_name: "${DC_ORO_NAME:-unnamed}_test_cli_${DC_ORO_PHP_VERSION:-8.3}-${DC_ORO_NODE_VERSION:-20}-${DC_ORO_COMPOSER_VERSION:-2}"
+    container_name: "${DC_ORO_NAME:-unnamed}_test_cli_${DC_ORO_PHP_VERSION:-8.4}-${DC_ORO_NODE_VERSION:-22}-${DC_ORO_COMPOSER_VERSION:-2}"
     hostname: test-cli.${DC_ORO_NAME:-unnamed}.docker.local
-    image: ghcr.io/digitalspacestdio/orodc-php-node-symfony:${DC_ORO_PHP_VERSION:-8.3}-${DC_ORO_NODE_VERSION:-20}-${DC_ORO_COMPOSER_VERSION:-2}-${DC_ORO_PHP_DIST:-alpine}
+    image: ghcr.io/digitalspacestdio/orodc-php-node-symfony:${DC_ORO_PHP_VERSION:-8.4}-${DC_ORO_NODE_VERSION:-22}-${DC_ORO_COMPOSER_VERSION:-2}-${DC_ORO_PHP_DIST:-alpine}
     user: "${DC_ORO_USER_NAME:-developer}"
     tmpfs:
       - /tmp:rw,size=256m

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -8,16 +8,16 @@ services:
     healthcheck:
       test: "sh -c 'exit 0'"
   fpm:
-    container_name: "${DC_ORO_NAME:-unnamed}_fpm_${DC_ORO_PHP_VERSION:-8.3}-${DC_ORO_NODE_VERSION:-20}-${DC_ORO_COMPOSER_VERSION:-2}"
+    container_name: "${DC_ORO_NAME:-unnamed}_fpm_${DC_ORO_PHP_VERSION:-8.4}-${DC_ORO_NODE_VERSION:-22}-${DC_ORO_COMPOSER_VERSION:-2}"
     hostname: fpm.${DC_ORO_NAME:-unnamed}.docker.local
-    image: ghcr.io/digitalspacestdio/orodc-php-node-symfony:${DC_ORO_PHP_VERSION:-8.3}-${DC_ORO_NODE_VERSION:-20}-${DC_ORO_COMPOSER_VERSION:-2}-${DC_ORO_PHP_DIST:-alpine}
+    image: ghcr.io/digitalspacestdio/orodc-php-node-symfony:${DC_ORO_PHP_VERSION:-8.4}-${DC_ORO_NODE_VERSION:-22}-${DC_ORO_COMPOSER_VERSION:-2}-${DC_ORO_PHP_DIST:-alpine}
     build:
-      dockerfile: Dockerfile.${DC_ORO_PHP_VERSION:-8.3}.${DC_ORO_PHP_DIST:-alpine}
+      dockerfile: Dockerfile.${DC_ORO_PHP_VERSION:-8.4}.${DC_ORO_PHP_DIST:-alpine}
       context: "${DC_ORO_CONFIG_DIR:-.}/docker/php-node-symfony"
       args:
         APP_DIR: "${DC_ORO_APPDIR:-/var/www}"
-        PHP_VERSION: "${DC_ORO_PHP_VERSION:-8.3}"
-        NODE_VERSION: "${DC_ORO_NODE_VERSION:-20}"
+        PHP_VERSION: "${DC_ORO_PHP_VERSION:-8.4}"
+        NODE_VERSION: "${DC_ORO_NODE_VERSION:-22}"
         PHP_USER_NAME: "${DC_ORO_PHP_USER_NAME:-developer}"
         PHP_USER_GROUP: "${DC_ORO_PHP_USER_GROUP:-developer}"
         PHP_UID: "${DC_ORO_PHP_UID:-1000}"
@@ -84,16 +84,16 @@ services:
         max-size: "10m"
 
   cli:
-    container_name: "${DC_ORO_NAME:-unnamed}_cli_${DC_ORO_PHP_VERSION:-8.3}-${DC_ORO_NODE_VERSION:-20}-${DC_ORO_COMPOSER_VERSION:-2}"
+    container_name: "${DC_ORO_NAME:-unnamed}_cli_${DC_ORO_PHP_VERSION:-8.4}-${DC_ORO_NODE_VERSION:-22}-${DC_ORO_COMPOSER_VERSION:-2}"
     hostname: cli.${DC_ORO_NAME:-unnamed}.docker.local
-    image: ghcr.io/digitalspacestdio/orodc-php-node-symfony:${DC_ORO_PHP_VERSION:-8.3}-${DC_ORO_NODE_VERSION:-20}-${DC_ORO_COMPOSER_VERSION:-2}-${DC_ORO_PHP_DIST:-alpine}
+    image: ghcr.io/digitalspacestdio/orodc-php-node-symfony:${DC_ORO_PHP_VERSION:-8.4}-${DC_ORO_NODE_VERSION:-22}-${DC_ORO_COMPOSER_VERSION:-2}-${DC_ORO_PHP_DIST:-alpine}
     build:
-      dockerfile: Dockerfile.${DC_ORO_PHP_VERSION:-8.3}.${DC_ORO_PHP_DIST:-alpine}
+      dockerfile: Dockerfile.${DC_ORO_PHP_VERSION:-8.4}.${DC_ORO_PHP_DIST:-alpine}
       context: "${DC_ORO_CONFIG_DIR:-.}/docker/php-node-symfony"
       args:
         APP_DIR: "${DC_ORO_APPDIR:-/var/www}"
-        PHP_VERSION: "${DC_ORO_PHP_VERSION:-8.3}"
-        NODE_VERSION: "${DC_ORO_NODE_VERSION:-20}"
+        PHP_VERSION: "${DC_ORO_PHP_VERSION:-8.4}"
+        NODE_VERSION: "${DC_ORO_NODE_VERSION:-22}"
         PHP_USER_NAME: "${DC_ORO_PHP_USER_NAME:-developer}"
         PHP_USER_GROUP: "${DC_ORO_PHP_USER_GROUP:-developer}"
         PHP_UID: "${DC_ORO_PHP_UID:-1000}"
@@ -161,17 +161,17 @@ services:
         max-size: "10m"
 
   consumer:
-    container_name: "${DC_ORO_NAME:-unnamed}_consumer_${DC_ORO_PHP_VERSION:-8.3}-${DC_ORO_NODE_VERSION:-20}-${DC_ORO_COMPOSER_VERSION:-2}"
+    container_name: "${DC_ORO_NAME:-unnamed}_consumer_${DC_ORO_PHP_VERSION:-8.4}-${DC_ORO_NODE_VERSION:-22}-${DC_ORO_COMPOSER_VERSION:-2}"
     hostname: consumer.${DC_ORO_NAME:-unnamed}.docker.local
     profiles: ["consumer"]
-    image: ghcr.io/digitalspacestdio/orodc-php-node-symfony:${DC_ORO_PHP_VERSION:-8.3}-${DC_ORO_NODE_VERSION:-20}-${DC_ORO_COMPOSER_VERSION:-2}-${DC_ORO_PHP_DIST:-alpine}
+    image: ghcr.io/digitalspacestdio/orodc-php-node-symfony:${DC_ORO_PHP_VERSION:-8.4}-${DC_ORO_NODE_VERSION:-22}-${DC_ORO_COMPOSER_VERSION:-2}-${DC_ORO_PHP_DIST:-alpine}
     build:
-      dockerfile: Dockerfile.${DC_ORO_PHP_VERSION:-8.3}.${DC_ORO_PHP_DIST:-alpine}
+      dockerfile: Dockerfile.${DC_ORO_PHP_VERSION:-8.4}.${DC_ORO_PHP_DIST:-alpine}
       context: "${DC_ORO_CONFIG_DIR:-.}/docker/php-node-symfony"
       args:
         APP_DIR: "${DC_ORO_APPDIR:-/var/www}"
-        PHP_VERSION: "${DC_ORO_PHP_VERSION:-8.3}"
-        NODE_VERSION: "${DC_ORO_NODE_VERSION:-20}"
+        PHP_VERSION: "${DC_ORO_PHP_VERSION:-8.4}"
+        NODE_VERSION: "${DC_ORO_NODE_VERSION:-22}"
         PHP_USER_NAME: "${DC_ORO_PHP_USER_NAME:-developer}"
         PHP_USER_GROUP: "${DC_ORO_PHP_USER_GROUP:-developer}"
         PHP_UID: "${DC_ORO_PHP_UID:-1000}"
@@ -237,17 +237,17 @@ services:
         max-size: "10m"
 
   websocket:
-    container_name: "${DC_ORO_NAME:-unnamed}_websocket_${DC_ORO_PHP_VERSION:-8.3}-${DC_ORO_NODE_VERSION:-20}-${DC_ORO_COMPOSER_VERSION:-2}"
+    container_name: "${DC_ORO_NAME:-unnamed}_websocket_${DC_ORO_PHP_VERSION:-8.4}-${DC_ORO_NODE_VERSION:-22}-${DC_ORO_COMPOSER_VERSION:-2}"
     hostname: websocket.${DC_ORO_NAME:-unnamed}.docker.local
     profiles: ["websocket"]
-    image: ghcr.io/digitalspacestdio/orodc-php-node-symfony:${DC_ORO_PHP_VERSION:-8.3}-${DC_ORO_NODE_VERSION:-20}-${DC_ORO_COMPOSER_VERSION:-2}-${DC_ORO_PHP_DIST:-alpine}
+    image: ghcr.io/digitalspacestdio/orodc-php-node-symfony:${DC_ORO_PHP_VERSION:-8.4}-${DC_ORO_NODE_VERSION:-22}-${DC_ORO_COMPOSER_VERSION:-2}-${DC_ORO_PHP_DIST:-alpine}
     build:
-      dockerfile: Dockerfile.${DC_ORO_PHP_VERSION:-8.3}.${DC_ORO_PHP_DIST:-alpine}
+      dockerfile: Dockerfile.${DC_ORO_PHP_VERSION:-8.4}.${DC_ORO_PHP_DIST:-alpine}
       context: "${DC_ORO_CONFIG_DIR:-.}/docker/php-node-symfony"
       args:
         APP_DIR: "${DC_ORO_APPDIR:-/var/www}"
-        PHP_VERSION: "${DC_ORO_PHP_VERSION:-8.3}"
-        NODE_VERSION: "${DC_ORO_NODE_VERSION:-20}"
+        PHP_VERSION: "${DC_ORO_PHP_VERSION:-8.4}"
+        NODE_VERSION: "${DC_ORO_NODE_VERSION:-22}"
         PHP_USER_NAME: "${DC_ORO_PHP_USER_NAME:-developer}"
         PHP_USER_GROUP: "${DC_ORO_PHP_USER_GROUP:-developer}"
         PHP_UID: "${DC_ORO_PHP_UID:-1000}"
@@ -316,7 +316,7 @@ services:
       retries: 18
 
   xhgui:
-    image: "xhgui/xhgui:0.18.3"
+    image: "xhgui/xhgui:0.18.4"
     hostname: xhgui.${DC_ORO_NAME:-unnamed}.docker.local
     profiles: ["xhprof"]
     volumes:
@@ -472,16 +472,16 @@ services:
         max-size: "10m"
 
   ssh:
-    container_name: "${DC_ORO_NAME:-unnamed}_ssh_${DC_ORO_PHP_VERSION:-8.3}-${DC_ORO_NODE_VERSION:-20}-${DC_ORO_COMPOSER_VERSION:-2}"
+    container_name: "${DC_ORO_NAME:-unnamed}_ssh_${DC_ORO_PHP_VERSION:-8.4}-${DC_ORO_NODE_VERSION:-22}-${DC_ORO_COMPOSER_VERSION:-2}"
     hostname: ssh.${DC_ORO_NAME:-unnamed}.docker.local
-    image: ghcr.io/digitalspacestdio/orodc-php-node-symfony:${DC_ORO_PHP_VERSION:-8.3}-${DC_ORO_NODE_VERSION:-20}-${DC_ORO_COMPOSER_VERSION:-2}-${DC_ORO_PHP_DIST:-alpine}
+    image: ghcr.io/digitalspacestdio/orodc-php-node-symfony:${DC_ORO_PHP_VERSION:-8.4}-${DC_ORO_NODE_VERSION:-22}-${DC_ORO_COMPOSER_VERSION:-2}-${DC_ORO_PHP_DIST:-alpine}
     build:
       context: "${DC_ORO_CONFIG_DIR:-.}/docker/php-node-symfony"
-      dockerfile: Dockerfile.${DC_ORO_PHP_VERSION:-8.3}.${DC_ORO_PHP_DIST:-alpine}
+      dockerfile: Dockerfile.${DC_ORO_PHP_VERSION:-8.4}.${DC_ORO_PHP_DIST:-alpine}
       args:
         APP_DIR: "${DC_ORO_APPDIR:-/var/www}"
-        PHP_VERSION: "${DC_ORO_PHP_VERSION:-8.3}"
-        NODE_VERSION: "${DC_ORO_NODE_VERSION:-20}"
+        PHP_VERSION: "${DC_ORO_PHP_VERSION:-8.4}"
+        NODE_VERSION: "${DC_ORO_NODE_VERSION:-22}"
         PHP_USER_NAME: "${DC_ORO_PHP_USER_NAME:-developer}"
         PHP_USER_GROUP: "${DC_ORO_PHP_USER_GROUP:-developer}"
         PHP_UID: "${DC_ORO_PHP_UID:-1000}"


### PR DESCRIPTION
- Fix version parsing to handle full versions like 6.0.8 instead of truncating to 6.0
- Add proper version comparison logic for determining PHP versions
- Update default versions: PHP 8.3→8.4, Node.js 20→22
- Ensure Oro 6.0.x uses PHP 8.3, Oro 6.1+ uses PHP 8.4
- Update fallback Node.js default from 20 to 22