### PR TITLE
feat: Add git HTTPS configuration to all PHP containers

### DIFF
--- a/Formula/docker-compose-oroplatform.rb
+++ b/Formula/docker-compose-oroplatform.rb
@@ -2,7 +2,7 @@ class DockerComposeOroplatform < Formula
   desc "CLI tool to run ORO applications locally or on a server"
   homepage "https://github.com/digitalspacestdio/homebrew-docker-compose-oroplatform"
   url "file:///dev/null"
-  version "0.8.6"
+  version "0.8.8"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
   def self.aliases

--- a/compose/docker/php-node-symfony/Dockerfile.7.4.alpine
+++ b/compose/docker/php-node-symfony/Dockerfile.7.4.alpine
@@ -260,5 +260,10 @@ RUN mkdir -p ${APP_DIR}; \
 
 WORKDIR ${APP_DIR}
 USER ${PHP_USER_NAME}
+
+# Configure git to use HTTPS instead of SSH for GitHub and GitLab
+RUN git config --global url."https://github.com/".insteadOf git@github.com: \
+    && git config --global url."https://gitlab.com/".insteadOf git@gitlab.com:
+
 VOLUME "/home/${PHP_USER_NAME}" "/root" "${APP_DIR}"
 CMD [ "zsh" ]

--- a/compose/docker/php-node-symfony/Dockerfile.8.1.alpine
+++ b/compose/docker/php-node-symfony/Dockerfile.8.1.alpine
@@ -247,5 +247,10 @@ RUN mkdir -p ${APP_DIR}; \
 
 WORKDIR ${APP_DIR}
 USER ${PHP_USER_NAME}
+
+# Configure git to use HTTPS instead of SSH for GitHub and GitLab
+RUN git config --global url."https://github.com/".insteadOf git@github.com: \
+    && git config --global url."https://gitlab.com/".insteadOf git@gitlab.com:
+
 VOLUME "/home/${PHP_USER_NAME}" "/root" "${APP_DIR}"
 CMD [ "zsh" ]

--- a/compose/docker/php-node-symfony/Dockerfile.8.2.alpine
+++ b/compose/docker/php-node-symfony/Dockerfile.8.2.alpine
@@ -248,5 +248,10 @@ RUN mkdir -p ${APP_DIR}; \
 
 WORKDIR ${APP_DIR}
 USER ${PHP_USER_NAME}
+
+# Configure git to use HTTPS instead of SSH for GitHub and GitLab
+RUN git config --global url."https://github.com/".insteadOf git@github.com: \
+    && git config --global url."https://gitlab.com/".insteadOf git@gitlab.com:
+
 VOLUME "/home/${PHP_USER_NAME}" "/root" "${APP_DIR}"
 CMD [ "zsh" ]

--- a/compose/docker/php-node-symfony/Dockerfile.8.3.alpine
+++ b/compose/docker/php-node-symfony/Dockerfile.8.3.alpine
@@ -247,5 +247,10 @@ RUN mkdir -p ${APP_DIR}; \
 
 WORKDIR ${APP_DIR}
 USER ${PHP_USER_NAME}
+
+# Configure git to use HTTPS instead of SSH for GitHub and GitLab
+RUN git config --global url."https://github.com/".insteadOf git@github.com: \
+    && git config --global url."https://gitlab.com/".insteadOf git@gitlab.com:
+
 VOLUME "/home/${PHP_USER_NAME}" "/root" "${APP_DIR}"
 CMD [ "zsh" ]

--- a/compose/docker/php-node-symfony/Dockerfile.8.4.alpine
+++ b/compose/docker/php-node-symfony/Dockerfile.8.4.alpine
@@ -256,5 +256,10 @@ RUN mkdir -p ${APP_DIR}; \
 
 WORKDIR ${APP_DIR}
 USER ${PHP_USER_NAME}
+
+# Configure git to use HTTPS instead of SSH for GitHub and GitLab
+RUN git config --global url."https://github.com/".insteadOf git@github.com: \
+    && git config --global url."https://gitlab.com/".insteadOf git@gitlab.com:
+
 VOLUME "/home/${PHP_USER_NAME}" "/root" "${APP_DIR}"
 CMD [ "zsh" ]


### PR DESCRIPTION
- Configure git to use HTTPS instead of SSH for GitHub and GitLab
- Applied to all PHP versions (7.4, 8.1, 8.2, 8.3, 8.4)
- Prevents SSH key issues in containerized environments
- Bump version to 0.8.8