### PR TITLE
feat: Configure self-hosted runners for multi-arch builds

### DIFF
--- a/.github/workflows/build-docker-nginx.yml
+++ b/.github/workflows/build-docker-nginx.yml
@@ -12,25 +12,77 @@ permissions:
   packages: write
 
 jobs:
-  build-nginx:
-    name: Build Nginx images
-    runs-on: ubuntu-latest
+  build-nginx-amd64:
+    name: Build Nginx AMD64
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Log in to GHCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build & Push Nginx Docker Image
-        uses: docker/build-push-action@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build & Push AMD64 Image
+        uses: docker/build-push-action@v5
         with:
           context: compose/docker/nginx
           file: compose/docker/nginx/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/orodc-nginx
+          tags: ghcr.io/${{ github.repository_owner }}/orodc-nginx:amd64
+          cache-from: type=gha,scope=nginx-amd64
+          cache-to: type=gha,mode=max,scope=nginx-amd64
+
+  build-nginx-arm64:
+    name: Build Nginx ARM64
+    runs-on: [self-hosted, Linux, ARM64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build & Push ARM64 Image
+        uses: docker/build-push-action@v5
+        with:
+          context: compose/docker/nginx
+          file: compose/docker/nginx/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/orodc-nginx:arm64
+          cache-from: type=gha,scope=nginx-arm64
+          cache-to: type=gha,mode=max,scope=nginx-arm64
+
+  create-nginx-manifest:
+    name: Create multi-arch manifest
+    needs: [build-nginx-amd64, build-nginx-arm64]
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push multi-arch manifest
+        run: |
+          # Create multi-arch manifest
+          docker buildx imagetools create \
+            --tag ghcr.io/${{ github.repository_owner }}/orodc-nginx:latest \
+            ghcr.io/${{ github.repository_owner }}/orodc-nginx:amd64 \
+            ghcr.io/${{ github.repository_owner }}/orodc-nginx:arm64
+          
+          # Also create without :latest suffix for backward compatibility
+          docker buildx imagetools create \
+            --tag ghcr.io/${{ github.repository_owner }}/orodc-nginx \
+            ghcr.io/${{ github.repository_owner }}/orodc-nginx:amd64 \
+            ghcr.io/${{ github.repository_owner }}/orodc-nginx:arm64

--- a/.github/workflows/build-docker-php-node-symfony.yml
+++ b/.github/workflows/build-docker-php-node-symfony.yml
@@ -12,9 +12,9 @@ permissions:
   packages: write
 
 jobs:
-  build-7-4:
-    name: Build PHP 7.4 images
-    runs-on: ubuntu-latest
+  build-7-4-amd64:
+    name: Build PHP 7.4 images (AMD64)
+    runs-on: [self-hosted, Linux, X64]
     strategy:
       matrix:
         php:      ["7.4"]
@@ -23,31 +23,92 @@ jobs:
         variant:  ["alpine"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Log in to GHCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build & Push PHP ${{ matrix.php }}-node${{ matrix.node }}-composer${{ matrix.composer }}-${{ matrix.variant }}
-        uses: docker/build-push-action@v4
+        uses: docker/setup-buildx-action@v3
+      - name: Build & Push PHP ${{ matrix.php }}-node${{ matrix.node }}-composer${{ matrix.composer }}-${{ matrix.variant }} (AMD64)
+        uses: docker/build-push-action@v5
         with:
           context: compose/docker/php-node-symfony
           file: compose/docker/php-node-symfony/Dockerfile.${{ matrix.php }}.${{ matrix.variant }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-${{ matrix.variant }}
+          tags: ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-${{ matrix.variant }}-amd64
           build-args: |
             PHP_VERSION=${{ matrix.php }}
             NODE_VERSION=${{ matrix.node }}
             COMPOSER_VERSION=${{ matrix.composer }}
+          cache-from: type=gha,scope=php-${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-amd64
+          cache-to: type=gha,mode=max,scope=php-${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-amd64
 
-  build-8-x:
-    name: Build PHP 8.x images
-    runs-on: ubuntu-latest
+  build-7-4-arm64:
+    name: Build PHP 7.4 images (ARM64)
+    runs-on: [self-hosted, Linux, ARM64]
+    strategy:
+      matrix:
+        php:      ["7.4"]
+        node:     ["16","18"]
+        composer: ["1","2"]
+        variant:  ["alpine"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build & Push PHP ${{ matrix.php }}-node${{ matrix.node }}-composer${{ matrix.composer }}-${{ matrix.variant }} (ARM64)
+        uses: docker/build-push-action@v5
+        with:
+          context: compose/docker/php-node-symfony
+          file: compose/docker/php-node-symfony/Dockerfile.${{ matrix.php }}.${{ matrix.variant }}
+          platforms: linux/arm64
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-${{ matrix.variant }}-arm64
+          build-args: |
+            PHP_VERSION=${{ matrix.php }}
+            NODE_VERSION=${{ matrix.node }}
+            COMPOSER_VERSION=${{ matrix.composer }}
+          cache-from: type=gha,scope=php-${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-arm64
+          cache-to: type=gha,mode=max,scope=php-${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-arm64
+
+  create-7-4-manifest:
+    name: Create PHP 7.4 multi-arch manifests
+    needs: [build-7-4-amd64, build-7-4-arm64]
+    runs-on: [self-hosted, Linux, X64]
+    strategy:
+      matrix:
+        php:      ["7.4"]
+        node:     ["16","18"]
+        composer: ["1","2"]
+        variant:  ["alpine"]
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create multi-arch manifest for ${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-${{ matrix.variant }}
+        run: |
+          docker buildx imagetools create \
+            --tag ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-${{ matrix.variant }} \
+            ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-${{ matrix.variant }}-amd64 \
+            ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-${{ matrix.variant }}-arm64
+
+  build-8-x-amd64:
+    name: Build PHP 8.x images (AMD64)
+    runs-on: [self-hosted, Linux, X64]
     strategy:
       matrix:
         php:      ["8.1","8.2","8.3","8.4"]
@@ -56,31 +117,92 @@ jobs:
         variant:  ["alpine"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Log in to GHCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build & Push PHP ${{ matrix.php }}-node${{ matrix.node }}-composer${{ matrix.composer }}-${{ matrix.variant }}
-        uses: docker/build-push-action@v4
+        uses: docker/setup-buildx-action@v3
+      - name: Build & Push PHP ${{ matrix.php }}-node${{ matrix.node }}-composer${{ matrix.composer }}-${{ matrix.variant }} (AMD64)
+        uses: docker/build-push-action@v5
         with:
           context: compose/docker/php-node-symfony
           file: compose/docker/php-node-symfony/Dockerfile.${{ matrix.php }}.${{ matrix.variant }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-${{ matrix.variant }}
+          tags: ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-${{ matrix.variant }}-amd64
           build-args: |
             PHP_VERSION=${{ matrix.php }}
             NODE_VERSION=${{ matrix.node }}
             COMPOSER_VERSION=${{ matrix.composer }}
+          cache-from: type=gha,scope=php-${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-amd64
+          cache-to: type=gha,mode=max,scope=php-${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-amd64
 
-  build-8-5:
-    name: Build PHP 8.5 images
-    runs-on: ubuntu-latest
+  build-8-x-arm64:
+    name: Build PHP 8.x images (ARM64)
+    runs-on: [self-hosted, Linux, ARM64]
+    strategy:
+      matrix:
+        php:      ["8.1","8.2","8.3","8.4"]
+        node:     ["18","20","22"]
+        composer: ["2"]
+        variant:  ["alpine"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build & Push PHP ${{ matrix.php }}-node${{ matrix.node }}-composer${{ matrix.composer }}-${{ matrix.variant }} (ARM64)
+        uses: docker/build-push-action@v5
+        with:
+          context: compose/docker/php-node-symfony
+          file: compose/docker/php-node-symfony/Dockerfile.${{ matrix.php }}.${{ matrix.variant }}
+          platforms: linux/arm64
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-${{ matrix.variant }}-arm64
+          build-args: |
+            PHP_VERSION=${{ matrix.php }}
+            NODE_VERSION=${{ matrix.node }}
+            COMPOSER_VERSION=${{ matrix.composer }}
+          cache-from: type=gha,scope=php-${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-arm64
+          cache-to: type=gha,mode=max,scope=php-${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-arm64
+
+  create-8-x-manifest:
+    name: Create PHP 8.x multi-arch manifests
+    needs: [build-8-x-amd64, build-8-x-arm64]
+    runs-on: [self-hosted, Linux, X64]
+    strategy:
+      matrix:
+        php:      ["8.1","8.2","8.3","8.4"]
+        node:     ["18","20","22"]
+        composer: ["2"]
+        variant:  ["alpine"]
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create multi-arch manifest for ${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-${{ matrix.variant }}
+        run: |
+          docker buildx imagetools create \
+            --tag ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-${{ matrix.variant }} \
+            ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-${{ matrix.variant }}-amd64 \
+            ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-${{ matrix.variant }}-arm64
+
+  build-8-5-amd64:
+    name: Build PHP 8.5 images (AMD64)
+    runs-on: [self-hosted, Linux, X64]
     strategy:
       matrix:
         php:      ["8.5"]
@@ -89,24 +211,85 @@ jobs:
         variant:  ["alpine"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Log in to GHCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build & Push PHP ${{ matrix.php }}-node${{ matrix.node }}-composer${{ matrix.composer }}-${{ matrix.variant }}
-        uses: docker/build-push-action@v4
+        uses: docker/setup-buildx-action@v3
+      - name: Build & Push PHP ${{ matrix.php }}-node${{ matrix.node }}-composer${{ matrix.composer }}-${{ matrix.variant }} (AMD64)
+        uses: docker/build-push-action@v5
         with:
           context: compose/docker/php-node-symfony
           file: compose/docker/php-node-symfony/Dockerfile.${{ matrix.php }}.${{ matrix.variant }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-${{ matrix.variant }}
+          tags: ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-${{ matrix.variant }}-amd64
           build-args: |
             PHP_VERSION=8.5-rc
             NODE_VERSION=${{ matrix.node }}
             COMPOSER_VERSION=${{ matrix.composer }}
+          cache-from: type=gha,scope=php-${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-amd64
+          cache-to: type=gha,mode=max,scope=php-${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-amd64
+
+  build-8-5-arm64:
+    name: Build PHP 8.5 images (ARM64)
+    runs-on: [self-hosted, Linux, ARM64]
+    strategy:
+      matrix:
+        php:      ["8.5"]
+        node:     ["22","24"]
+        composer: ["2"]
+        variant:  ["alpine"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build & Push PHP ${{ matrix.php }}-node${{ matrix.node }}-composer${{ matrix.composer }}-${{ matrix.variant }} (ARM64)
+        uses: docker/build-push-action@v5
+        with:
+          context: compose/docker/php-node-symfony
+          file: compose/docker/php-node-symfony/Dockerfile.${{ matrix.php }}.${{ matrix.variant }}
+          platforms: linux/arm64
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-${{ matrix.variant }}-arm64
+          build-args: |
+            PHP_VERSION=8.5-rc
+            NODE_VERSION=${{ matrix.node }}
+            COMPOSER_VERSION=${{ matrix.composer }}
+          cache-from: type=gha,scope=php-${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-arm64
+          cache-to: type=gha,mode=max,scope=php-${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-arm64
+
+  create-8-5-manifest:
+    name: Create PHP 8.5 multi-arch manifests
+    needs: [build-8-5-amd64, build-8-5-arm64]
+    runs-on: [self-hosted, Linux, X64]
+    strategy:
+      matrix:
+        php:      ["8.5"]
+        node:     ["22","24"]
+        composer: ["2"]
+        variant:  ["alpine"]
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create multi-arch manifest for ${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-${{ matrix.variant }}
+        run: |
+          docker buildx imagetools create \
+            --tag ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-${{ matrix.variant }} \
+            ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-${{ matrix.variant }}-amd64 \
+            ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-${{ matrix.node }}-${{ matrix.composer }}-${{ matrix.variant }}-arm64

--- a/.github/workflows/test-oro-installations.yml
+++ b/.github/workflows/test-oro-installations.yml
@@ -26,11 +26,11 @@ env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1
 
 jobs:
-  test-installation:
-    runs-on: ubuntu-latest
+  test-installation-x64:
+    runs-on: [self-hosted, Linux, X64]
     strategy:
       fail-fast: false
-      max-parallel: 1  # Run jobs sequentially to avoid conflicts
+      max-parallel: 2  # Run up to 2 jobs in parallel on X64
       matrix:
         include:
           - application: oroplatform
@@ -46,7 +46,186 @@ jobs:
             version: 6.1.0
             repo_url: https://github.com/marellocommerce/marello-application.git
     timeout-minutes: 90
-    name: Test ${{ matrix.application }} (${{ matrix.version }})
+    name: Test ${{ matrix.application }} (${{ matrix.version }}) [X64]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Install Homebrew
+        run: |
+          # Configure git to use HTTPS instead of SSH BEFORE Homebrew installation
+          git config --global url."https://github.com/".insteadOf git@github.com:
+          
+          # Install Homebrew (always fresh installation)
+          echo "Installing Homebrew..."
+          NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH
+
+      - name: Install OroDC
+        run: |
+          # Install tap first
+          brew tap digitalspacestdio/docker-compose-oroplatform
+          
+          # Copy current source files to tap directory (overwrite with current version)
+          TAP_DIR="/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/digitalspacestdio/homebrew-docker-compose-oroplatform"
+          cp -r bin/ "$TAP_DIR/"
+          cp -r compose/ "$TAP_DIR/"
+          cp Formula/docker-compose-oroplatform.rb "$TAP_DIR/Formula/"
+          
+          # Install OroDC from current source
+          brew install digitalspacestdio/docker-compose-oroplatform/docker-compose-oroplatform
+          
+          # Verify installation
+          orodc version
+
+      - name: Clone Oro application
+        run: |
+          # Set unique project name and port to avoid conflicts
+          PROJECT_NAME="${{ matrix.application }}-${{ github.run_id }}-x64"
+          PORT_PREFIX="31${{ strategy.job-index }}"
+          WORK_DIR="${{ github.workspace }}/$PROJECT_NAME"
+          
+          echo "📦 Cloning ${{ matrix.application }} version ${{ matrix.version }} [X64]"
+          echo "🏷️  Project: $PROJECT_NAME"
+          echo "📂 Work directory: $WORK_DIR"
+          echo "🔌 Port prefix: $PORT_PREFIX"
+          echo "🏠 Workspace: ${{ github.workspace }}"
+          
+          # Create work directory in workspace (shared with host Docker)
+          mkdir -p "$WORK_DIR"
+          
+          # Clone the application
+          if ! git clone --single-branch --branch "${{ matrix.version }}" "${{ matrix.repo_url }}" "$WORK_DIR"; then
+            echo "⚠️  Failed to clone version ${{ matrix.version }}, trying master..."
+            git clone "${{ matrix.repo_url }}" "$WORK_DIR"
+            cd "$WORK_DIR"
+            if git tag | grep -q "${{ matrix.version }}"; then
+              git checkout "${{ matrix.version }}"
+            else
+              echo "⚠️  Using default branch"
+            fi
+          else
+            cd "$WORK_DIR"
+          fi
+          
+          # Configure OroDC for SSH mode (no volume mounting needed)
+          echo "DC_ORO_NAME=$PROJECT_NAME" > .env.orodc
+          echo "DC_ORO_PORT_PREFIX=$PORT_PREFIX" >> .env.orodc
+          echo "DC_ORO_MODE=ssh" >> .env.orodc
+          
+          echo "✅ Application cloned and configured in $WORK_DIR [X64]"
+
+      - name: Install and start application
+        run: |
+          cd "${{ github.workspace }}/${{ matrix.application }}-${{ github.run_id }}-x64"
+          echo "🚀 Starting installation of ${{ matrix.application }} [X64]..."
+          echo "📁 Working in: $(pwd)"
+          
+          # Install the application
+          orodc install
+          
+          # Start services
+          orodc up -d
+          
+          echo "✅ Installation completed [X64]"
+
+      - name: Wait for services to be ready
+        run: |
+          cd "${{ github.workspace }}/${{ matrix.application }}-${{ github.run_id }}-x64"
+          echo "⏳ Waiting for services to start [X64]..."
+          
+          # Wait up to 10 minutes for services to be ready
+          timeout 600 bash -c '
+            while ! orodc ps | grep -q "Up"; do
+              echo "Waiting for services..."
+              sleep 10
+            done
+          '
+          
+          echo "✅ Services are running [X64]"
+
+      - name: Test application accessibility
+        run: |
+          cd "${{ github.workspace }}/${{ matrix.application }}-${{ github.run_id }}-x64"
+          # Get the HTTP port
+          HTTP_PORT="31${{ strategy.job-index }}80"
+          echo "🌐 Testing accessibility on http://localhost:$HTTP_PORT [X64]"
+          
+          # Wait for HTTP response (up to 5 minutes)
+          timeout 300 bash -c "
+            until curl -s http://localhost:$HTTP_PORT >/dev/null; do
+              echo 'Waiting for HTTP response...'
+              sleep 5
+            done
+          "
+          
+          # Get page title
+          TITLE=$(curl -s "http://localhost:$HTTP_PORT" | grep -o '<title>[^<]*</title>' | sed 's/<[^>]*>//g' || echo "No title found")
+          echo "📄 Page title: $TITLE"
+          
+          echo "✅ Application is accessible [X64]"
+
+      - name: Run basic health checks
+        run: |
+          cd "${{ github.workspace }}/${{ matrix.application }}-${{ github.run_id }}-x64"
+          echo "🔍 Running health checks [X64]..."
+          
+          # Check container status
+          echo "📋 Container status:"
+          orodc ps
+          
+          # Check PHP version
+          echo "🐘 PHP version:"
+          orodc php --version
+          
+          # Check database connection
+          echo "🗄️  Database connection:"
+          orodc psql -c "SELECT version();" || echo "Database check failed"
+          
+          echo "✅ Health checks completed [X64]"
+
+      - name: Cleanup on failure
+        if: failure()
+        run: |
+          cd "${{ github.workspace }}/${{ matrix.application }}-${{ github.run_id }}-x64" 2>/dev/null || true
+          echo "🧹 Cleaning up after failure [X64]..."
+          orodc logs --tail=50 || true
+          orodc down --remove-orphans || true
+          orodc purge || true
+
+      - name: Cleanup on success
+        if: success()
+        run: |
+          cd "${{ github.workspace }}/${{ matrix.application }}-${{ github.run_id }}-x64" 2>/dev/null || true
+          echo "🧹 Cleaning up after success [X64]..."
+          orodc down --remove-orphans || true
+          orodc purge || true
+
+  test-installation-arm64:
+    runs-on: [self-hosted, Linux, ARM64]
+    strategy:
+      fail-fast: false
+      max-parallel: 2  # Run up to 2 jobs in parallel on ARM64
+      matrix:
+        include:
+          - application: oroplatform
+            version: 6.1.4
+            repo_url: https://github.com/oroinc/platform-application.git
+          - application: orocrm
+            version: 6.1.4
+            repo_url: https://github.com/oroinc/crm-application.git
+          - application: orocommerce
+            version: 6.1.4
+            repo_url: https://github.com/oroinc/orocommerce-application.git
+          - application: marello
+            version: 6.1.0
+            repo_url: https://github.com/marellocommerce/marello-application.git
+    timeout-minutes: 90
+    name: Test ${{ matrix.application }} (${{ matrix.version }}) [ARM64]
     
     steps:
       - name: Checkout repository
@@ -82,15 +261,14 @@ jobs:
           # Verify installation
           orodc version
 
-
       - name: Clone Oro application
         run: |
           # Set unique project name and port to avoid conflicts
-          PROJECT_NAME="${{ matrix.application }}-${{ github.run_id }}"
-          PORT_PREFIX="30${{ strategy.job-index }}"
+          PROJECT_NAME="${{ matrix.application }}-${{ github.run_id }}-arm64"
+          PORT_PREFIX="32${{ strategy.job-index }}"
           WORK_DIR="${{ github.workspace }}/$PROJECT_NAME"
           
-          echo "📦 Cloning ${{ matrix.application }} version ${{ matrix.version }}"
+          echo "📦 Cloning ${{ matrix.application }} version ${{ matrix.version }} [ARM64]"
           echo "🏷️  Project: $PROJECT_NAME"
           echo "📂 Work directory: $WORK_DIR"
           echo "🔌 Port prefix: $PORT_PREFIX"
@@ -118,12 +296,12 @@ jobs:
           echo "DC_ORO_PORT_PREFIX=$PORT_PREFIX" >> .env.orodc
           echo "DC_ORO_MODE=ssh" >> .env.orodc
           
-          echo "✅ Application cloned and configured in $WORK_DIR"
+          echo "✅ Application cloned and configured in $WORK_DIR [ARM64]"
 
       - name: Install and start application
         run: |
-          cd "${{ github.workspace }}/${{ matrix.application }}-${{ github.run_id }}"
-          echo "🚀 Starting installation of ${{ matrix.application }}..."
+          cd "${{ github.workspace }}/${{ matrix.application }}-${{ github.run_id }}-arm64"
+          echo "🚀 Starting installation of ${{ matrix.application }} [ARM64]..."
           echo "📁 Working in: $(pwd)"
           
           # Install the application
@@ -132,12 +310,12 @@ jobs:
           # Start services
           orodc up -d
           
-          echo "✅ Installation completed"
+          echo "✅ Installation completed [ARM64]"
 
       - name: Wait for services to be ready
         run: |
-          cd "${{ github.workspace }}/${{ matrix.application }}-${{ github.run_id }}"
-          echo "⏳ Waiting for services to start..."
+          cd "${{ github.workspace }}/${{ matrix.application }}-${{ github.run_id }}-arm64"
+          echo "⏳ Waiting for services to start [ARM64]..."
           
           # Wait up to 10 minutes for services to be ready
           timeout 600 bash -c '
@@ -147,14 +325,14 @@ jobs:
             done
           '
           
-          echo "✅ Services are running"
+          echo "✅ Services are running [ARM64]"
 
       - name: Test application accessibility
         run: |
-          cd "${{ github.workspace }}/${{ matrix.application }}-${{ github.run_id }}"
+          cd "${{ github.workspace }}/${{ matrix.application }}-${{ github.run_id }}-arm64"
           # Get the HTTP port
-          HTTP_PORT="30${{ strategy.job-index }}80"
-          echo "🌐 Testing accessibility on http://localhost:$HTTP_PORT"
+          HTTP_PORT="32${{ strategy.job-index }}80"
+          echo "🌐 Testing accessibility on http://localhost:$HTTP_PORT [ARM64]"
           
           # Wait for HTTP response (up to 5 minutes)
           timeout 300 bash -c "
@@ -168,12 +346,12 @@ jobs:
           TITLE=$(curl -s "http://localhost:$HTTP_PORT" | grep -o '<title>[^<]*</title>' | sed 's/<[^>]*>//g' || echo "No title found")
           echo "📄 Page title: $TITLE"
           
-          echo "✅ Application is accessible"
+          echo "✅ Application is accessible [ARM64]"
 
       - name: Run basic health checks
         run: |
-          cd "${{ github.workspace }}/${{ matrix.application }}-${{ github.run_id }}"
-          echo "🔍 Running health checks..."
+          cd "${{ github.workspace }}/${{ matrix.application }}-${{ github.run_id }}-arm64"
+          echo "🔍 Running health checks [ARM64]..."
           
           # Check container status
           echo "📋 Container status:"
@@ -187,13 +365,13 @@ jobs:
           echo "🗄️  Database connection:"
           orodc psql -c "SELECT version();" || echo "Database check failed"
           
-          echo "✅ Health checks completed"
+          echo "✅ Health checks completed [ARM64]"
 
       - name: Cleanup on failure
         if: failure()
         run: |
-          cd "${{ github.workspace }}/${{ matrix.application }}-${{ github.run_id }}" 2>/dev/null || true
-          echo "🧹 Cleaning up after failure..."
+          cd "${{ github.workspace }}/${{ matrix.application }}-${{ github.run_id }}-arm64" 2>/dev/null || true
+          echo "🧹 Cleaning up after failure [ARM64]..."
           orodc logs --tail=50 || true
           orodc down --remove-orphans || true
           orodc purge || true
@@ -201,14 +379,14 @@ jobs:
       - name: Cleanup on success
         if: success()
         run: |
-          cd "/tmp/${{ matrix.application }}-${{ github.run_id }}" 2>/dev/null || true
-          echo "🧹 Cleaning up after success..."
+          cd "${{ github.workspace }}/${{ matrix.application }}-${{ github.run_id }}-arm64" 2>/dev/null || true
+          echo "🧹 Cleaning up after success [ARM64]..."
           orodc down --remove-orphans || true
           orodc purge || true
 
   test-summary:
-    needs: test-installation
-    runs-on: ubuntu-latest
+    needs: [test-installation-x64, test-installation-arm64]
+    runs-on: [self-hosted, Linux, X64]
     if: always()
     steps:
       - name: Test Summary
@@ -216,15 +394,22 @@ jobs:
           echo "## Test Results Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           
-          if [ "${{ needs.test-installation.result }}" = "success" ]; then
-            echo "✅ All installation tests passed successfully!" >> $GITHUB_STEP_SUMMARY
+          X64_RESULT="${{ needs.test-installation-x64.result }}"
+          ARM64_RESULT="${{ needs.test-installation-arm64.result }}"
+          
+          if [ "$X64_RESULT" = "success" ] && [ "$ARM64_RESULT" = "success" ]; then
+            echo "✅ All installation tests passed successfully on both architectures!" >> $GITHUB_STEP_SUMMARY
           else
             echo "❌ Some installation tests failed. Check the job logs for details." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Results by Architecture:" >> $GITHUB_STEP_SUMMARY
+            echo "- **X64 (AMD64)**: $X64_RESULT" >> $GITHUB_STEP_SUMMARY
+            echo "- **ARM64**: $ARM64_RESULT" >> $GITHUB_STEP_SUMMARY
           fi
           
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Tested Applications:" >> $GITHUB_STEP_SUMMARY
-          echo "- oroplatform (6.1.4)" >> $GITHUB_STEP_SUMMARY
-          echo "- orocrm (6.1.4)" >> $GITHUB_STEP_SUMMARY
-          echo "- orocommerce (6.1.4)" >> $GITHUB_STEP_SUMMARY
-          echo "- marello (6.1.0)" >> $GITHUB_STEP_SUMMARY
+          echo "- oroplatform (6.1.4) - tested on X64 and ARM64" >> $GITHUB_STEP_SUMMARY
+          echo "- orocrm (6.1.4) - tested on X64 and ARM64" >> $GITHUB_STEP_SUMMARY
+          echo "- orocommerce (6.1.4) - tested on X64 and ARM64" >> $GITHUB_STEP_SUMMARY
+          echo "- marello (6.1.0) - tested on X64 and ARM64" >> $GITHUB_STEP_SUMMARY

--- a/Formula/docker-compose-oroplatform.rb
+++ b/Formula/docker-compose-oroplatform.rb
@@ -2,7 +2,7 @@ class DockerComposeOroplatform < Formula
   desc "CLI tool to run ORO applications locally or on a server"
   homepage "https://github.com/digitalspacestdio/homebrew-docker-compose-oroplatform"
   url "file:///dev/null"
-  version "0.11.4"
+  version "0.11.5"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
   def self.aliases


### PR DESCRIPTION
- Update Docker workflows to use self-hosted runners with X64 and ARM64 tags
- Split Docker builds into separate AMD64 and ARM64 jobs for better performance
- Add multi-arch manifest creation using docker buildx imagetools
- Configure GitHub Actions cache for each architecture separately
- Update test workflows to run on both X64 and ARM64 architectures
- Increment formula version to 0.11.5

This provides:
- Faster native builds on each architecture
- Parallel execution of AMD64 and ARM64 builds
- Better reliability with architecture-specific isolation
- Comprehensive testing across both platforms