### PR TITLE
fix: Simplify Homebrew non-root setup with full sudo access

### DIFF
--- a/.github/workflows/test-oro-installations.yml
+++ b/.github/workflows/test-oro-installations.yml
@@ -80,13 +80,12 @@ jobs:
             # Create necessary directories
             mkdir -p "$RUNNER_HOME"
             mkdir -p /tmp/hostedtoolcache
-            
-            # Set proper ownership
             chown -R github-runner:github-runner "$RUNNER_HOME"
             chown -R github-runner:github-runner /tmp/hostedtoolcache
             
-            # Add github-runner to sudo group
-            usermod -aG sudo github-runner
+            # Give github-runner full sudo access without password
+            echo "github-runner ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/github-runner
+            chmod 440 /etc/sudoers.d/github-runner
             
             echo "RUNNER_USER=github-runner" >> $GITHUB_ENV
             echo "RUNNER_HOME=/home/github-runner" >> $GITHUB_ENV
@@ -340,13 +339,12 @@ jobs:
             # Create necessary directories
             mkdir -p "$RUNNER_HOME"
             mkdir -p /tmp/hostedtoolcache
-            
-            # Set proper ownership
             chown -R github-runner:github-runner "$RUNNER_HOME"
             chown -R github-runner:github-runner /tmp/hostedtoolcache
             
-            # Add github-runner to sudo group
-            usermod -aG sudo github-runner
+            # Give github-runner full sudo access without password
+            echo "github-runner ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/github-runner
+            chmod 440 /etc/sudoers.d/github-runner
             
             echo "RUNNER_USER=github-runner" >> $GITHUB_ENV
             echo "RUNNER_HOME=/home/github-runner" >> $GITHUB_ENV

--- a/Formula/docker-compose-oroplatform.rb
+++ b/Formula/docker-compose-oroplatform.rb
@@ -2,7 +2,7 @@ class DockerComposeOroplatform < Formula
   desc "CLI tool to run ORO applications locally or on a server"
   homepage "https://github.com/digitalspacestdio/homebrew-docker-compose-oroplatform"
   url "file:///dev/null"
-  version "0.11.7"
+  version "0.11.8"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
   def self.aliases


### PR DESCRIPTION
- Give github-runner user full sudo access without password
- Remove complex permissions management logic
- Let Homebrew installer handle directory creation and permissions
- Simplify user environment setup
- Increment formula version to 0.11.8

This provides a cleaner solution for the Homebrew 'Don't run this as root!' error by giving the non-root user all necessary permissions.