### PR TITLE
feat: Add DEBUG=1 flag to all OroDC commands in workflows

### DIFF
--- a/.github/workflows/test-oro-installations.yml
+++ b/.github/workflows/test-oro-installations.yml
@@ -132,17 +132,34 @@ jobs:
           # Function to run commands as the runner user
           run_as_user() {
             if [ "$(whoami)" = "root" ]; then
+              echo "Running as github-runner: $*"
               sudo -u "$RUNNER_USER" -H "$@"
             else
+              echo "Running as $(whoami): $*"
               "$@"
             fi
           }
           
+          echo "=== Installing OroDC Debug ==="
+          echo "Current user: $(whoami)"
+          echo "RUNNER_USER: $RUNNER_USER"
+          echo "RUNNER_HOME: $RUNNER_HOME"
+          
+          # Check Homebrew installation
+          echo "Checking Homebrew installation:"
+          ls -la /home/linuxbrew/.linuxbrew/bin/brew || echo "Homebrew not found!"
+          run_as_user /home/linuxbrew/.linuxbrew/bin/brew --version || echo "Homebrew version check failed!"
+          
           # Install tap first
-          run_as_user /home/linuxbrew/.linuxbrew/bin/brew tap digitalspacestdio/docker-compose-oroplatform
+          echo "Installing tap..."
+          if ! run_as_user /home/linuxbrew/.linuxbrew/bin/brew tap digitalspacestdio/docker-compose-oroplatform; then
+            echo "❌ Brew tap failed!"
+            exit 1
+          fi
           
           # Copy current source files to tap directory (overwrite with current version)
           TAP_DIR="/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/digitalspacestdio/homebrew-docker-compose-oroplatform"
+          echo "Copying source files to: $TAP_DIR"
           
           # Ensure tap directory is owned by runner user
           if [ "$(whoami)" = "root" ]; then
@@ -158,11 +175,28 @@ jobs:
             chown -R "$RUNNER_USER:$RUNNER_USER" "$TAP_DIR"
           fi
           
+          echo "Checking copied files:"
+          ls -la "$TAP_DIR/bin/" || echo "bin/ directory not found"
+          ls -la "$TAP_DIR/Formula/" || echo "Formula/ directory not found"
+          
           # Install OroDC from current source
-          run_as_user /home/linuxbrew/.linuxbrew/bin/brew install digitalspacestdio/docker-compose-oroplatform/docker-compose-oroplatform
+          echo "Installing OroDC..."
+          if ! run_as_user /home/linuxbrew/.linuxbrew/bin/brew install digitalspacestdio/docker-compose-oroplatform/docker-compose-oroplatform; then
+            echo "❌ Brew install failed!"
+            echo "Checking brew logs..."
+            run_as_user /home/linuxbrew/.linuxbrew/bin/brew doctor || echo "Brew doctor failed"
+            exit 1
+          fi
           
           # Verify installation
-          run_as_user /home/linuxbrew/.linuxbrew/bin/orodc version
+          echo "Verifying OroDC installation:"
+          ls -la /home/linuxbrew/.linuxbrew/bin/orodc || echo "OroDC binary not found!"
+          if ! run_as_user env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc version; then
+            echo "❌ OroDC version check failed!"
+            exit 1
+          fi
+          
+          echo "✅ OroDC installation completed successfully"
 
       - name: Clone Oro application
         run: |
@@ -203,26 +237,63 @@ jobs:
 
       - name: Install and start application
         run: |
-          # Setup environment for this step
+          # Setup environment for this step with detailed logging
+          echo "=== Environment Setup Debug [X64] ==="
+          echo "Current user: $(whoami)"
+          echo "Current HOME: ${HOME:-'not set'}"
+          echo "Current PWD: $(pwd)"
+          echo "Environment variables:"
+          env | grep -E "(RUNNER|HOME|USER)" | sort || echo "No relevant env vars found"
+          
           if [ "$(whoami)" = "root" ]; then
             export RUNNER_USER="github-runner"
-            export RUNNER_HOME="/home/github-runner"
-            run_as_user() { sudo -u "$RUNNER_USER" -H "$@"; }
+            export RUNNER_HOME="/home/github-runner" 
+            echo "Setting up for root user -> github-runner"
+            run_as_user() { 
+              echo "Running as github-runner: $*"
+              sudo -u "$RUNNER_USER" -H "$@"
+            }
           else
             export RUNNER_USER="$(whoami)"
             export RUNNER_HOME="${HOME:-/home/$RUNNER_USER}"
-            run_as_user() { "$@"; }
+            echo "Setting up for non-root user: $RUNNER_USER"
+            run_as_user() { 
+              echo "Running as $RUNNER_USER: $*"
+              "$@"
+            }
           fi
+          
+          echo "Final environment:"
+          echo "RUNNER_USER=$RUNNER_USER"
+          echo "RUNNER_HOME=$RUNNER_HOME"
+          echo "=== End Environment Setup ==="
           
           cd "${{ github.workspace }}/${{ matrix.application }}-${{ github.run_id }}-x64"
           echo "🚀 Starting installation of ${{ matrix.application }} [X64]..."
           echo "📁 Working in: $(pwd)"
           
+          # Check if orodc exists and is executable
+          echo "Checking OroDC binary:"
+          ls -la /home/linuxbrew/.linuxbrew/bin/orodc || echo "OroDC binary not found!"
+          
           # Install the application
-          run_as_user /home/linuxbrew/.linuxbrew/bin/orodc install
+          echo "Installing application..."
+          if ! run_as_user env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc install; then
+            echo "❌ OroDC install failed!"
+            echo "Checking OroDC status..."
+            run_as_user env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc --version || echo "OroDC version check failed"
+            exit 1
+          fi
           
           # Start services
-          run_as_user /home/linuxbrew/.linuxbrew/bin/orodc up -d
+          echo "Starting services..."
+          if ! run_as_user env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc up -d; then
+            echo "❌ OroDC up failed!"
+            echo "Checking docker status..."
+            docker --version || echo "Docker not available"
+            run_as_user docker compose version || echo "Docker Compose not available"
+            exit 1
+          fi
           
           echo "✅ Installation completed [X64]"
 
@@ -245,14 +316,14 @@ jobs:
           # Wait up to 10 minutes for services to be ready
           if [ "$(whoami)" = "root" ]; then
             timeout 600 bash -c '
-              while ! sudo -u github-runner -H /home/linuxbrew/.linuxbrew/bin/orodc ps | grep -q "Up"; do
+              while ! sudo -u github-runner -H env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc ps | grep -q "Up"; do
                 echo "Waiting for services..."
                 sleep 10
               done
             '
           else
             timeout 600 bash -c '
-              while ! /home/linuxbrew/.linuxbrew/bin/orodc ps | grep -q "Up"; do
+              while ! env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc ps | grep -q "Up"; do
                 echo "Waiting for services..."
                 sleep 10
               done
@@ -300,15 +371,15 @@ jobs:
           
           # Check container status
           echo "📋 Container status:"
-          run_as_user /home/linuxbrew/.linuxbrew/bin/orodc ps
+          run_as_user env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc ps
           
           # Check PHP version
           echo "🐘 PHP version:"
-          run_as_user /home/linuxbrew/.linuxbrew/bin/orodc php --version
+          run_as_user env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc php --version
           
           # Check database connection
           echo "🗄️  Database connection:"
-          run_as_user /home/linuxbrew/.linuxbrew/bin/orodc psql -c "SELECT version();" || echo "Database check failed"
+          run_as_user env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc psql -c "SELECT version();" || echo "Database check failed"
           
           echo "✅ Health checks completed [X64]"
 
@@ -324,9 +395,9 @@ jobs:
           
           cd "${{ github.workspace }}/${{ matrix.application }}-${{ github.run_id }}-x64" 2>/dev/null || true
           echo "🧹 Cleaning up after failure [X64]..."
-          run_as_user /home/linuxbrew/.linuxbrew/bin/orodc logs --tail=50 || true
-          run_as_user /home/linuxbrew/.linuxbrew/bin/orodc down --remove-orphans || true
-          run_as_user /home/linuxbrew/.linuxbrew/bin/orodc purge || true
+          run_as_user env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc logs --tail=50 || true
+          run_as_user env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc down --remove-orphans || true
+          run_as_user env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc purge || true
 
       - name: Cleanup on success
         if: success()
@@ -340,8 +411,8 @@ jobs:
           
           cd "${{ github.workspace }}/${{ matrix.application }}-${{ github.run_id }}-x64" 2>/dev/null || true
           echo "🧹 Cleaning up after success [X64]..."
-          run_as_user /home/linuxbrew/.linuxbrew/bin/orodc down --remove-orphans || true
-          run_as_user /home/linuxbrew/.linuxbrew/bin/orodc purge || true
+          run_as_user env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc down --remove-orphans || true
+          run_as_user env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc purge || true
 
   test-installation-arm64:
     runs-on: [self-hosted, Linux, ARM64]
@@ -447,17 +518,34 @@ jobs:
           # Function to run commands as the runner user
           run_as_user() {
             if [ "$(whoami)" = "root" ]; then
+              echo "Running as github-runner: $*"
               sudo -u "$RUNNER_USER" -H "$@"
             else
+              echo "Running as $(whoami): $*"
               "$@"
             fi
           }
           
+          echo "=== Installing OroDC Debug ==="
+          echo "Current user: $(whoami)"
+          echo "RUNNER_USER: $RUNNER_USER"
+          echo "RUNNER_HOME: $RUNNER_HOME"
+          
+          # Check Homebrew installation
+          echo "Checking Homebrew installation:"
+          ls -la /home/linuxbrew/.linuxbrew/bin/brew || echo "Homebrew not found!"
+          run_as_user /home/linuxbrew/.linuxbrew/bin/brew --version || echo "Homebrew version check failed!"
+          
           # Install tap first
-          run_as_user /home/linuxbrew/.linuxbrew/bin/brew tap digitalspacestdio/docker-compose-oroplatform
+          echo "Installing tap..."
+          if ! run_as_user /home/linuxbrew/.linuxbrew/bin/brew tap digitalspacestdio/docker-compose-oroplatform; then
+            echo "❌ Brew tap failed!"
+            exit 1
+          fi
           
           # Copy current source files to tap directory (overwrite with current version)
           TAP_DIR="/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/digitalspacestdio/homebrew-docker-compose-oroplatform"
+          echo "Copying source files to: $TAP_DIR"
           
           # Ensure tap directory is owned by runner user
           if [ "$(whoami)" = "root" ]; then
@@ -473,11 +561,28 @@ jobs:
             chown -R "$RUNNER_USER:$RUNNER_USER" "$TAP_DIR"
           fi
           
+          echo "Checking copied files:"
+          ls -la "$TAP_DIR/bin/" || echo "bin/ directory not found"
+          ls -la "$TAP_DIR/Formula/" || echo "Formula/ directory not found"
+          
           # Install OroDC from current source
-          run_as_user /home/linuxbrew/.linuxbrew/bin/brew install digitalspacestdio/docker-compose-oroplatform/docker-compose-oroplatform
+          echo "Installing OroDC..."
+          if ! run_as_user /home/linuxbrew/.linuxbrew/bin/brew install digitalspacestdio/docker-compose-oroplatform/docker-compose-oroplatform; then
+            echo "❌ Brew install failed!"
+            echo "Checking brew logs..."
+            run_as_user /home/linuxbrew/.linuxbrew/bin/brew doctor || echo "Brew doctor failed"
+            exit 1
+          fi
           
           # Verify installation
-          run_as_user /home/linuxbrew/.linuxbrew/bin/orodc version
+          echo "Verifying OroDC installation:"
+          ls -la /home/linuxbrew/.linuxbrew/bin/orodc || echo "OroDC binary not found!"
+          if ! run_as_user env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc version; then
+            echo "❌ OroDC version check failed!"
+            exit 1
+          fi
+          
+          echo "✅ OroDC installation completed successfully"
 
       - name: Clone Oro application
         run: |
@@ -518,26 +623,63 @@ jobs:
 
       - name: Install and start application
         run: |
-          # Setup environment for this step
+          # Setup environment for this step with detailed logging
+          echo "=== Environment Setup Debug [ARM64] ==="
+          echo "Current user: $(whoami)"
+          echo "Current HOME: ${HOME:-'not set'}"
+          echo "Current PWD: $(pwd)"
+          echo "Environment variables:"
+          env | grep -E "(RUNNER|HOME|USER)" | sort || echo "No relevant env vars found"
+          
           if [ "$(whoami)" = "root" ]; then
             export RUNNER_USER="github-runner"
-            export RUNNER_HOME="/home/github-runner"
-            run_as_user() { sudo -u "$RUNNER_USER" -H "$@"; }
+            export RUNNER_HOME="/home/github-runner" 
+            echo "Setting up for root user -> github-runner"
+            run_as_user() { 
+              echo "Running as github-runner: $*"
+              sudo -u "$RUNNER_USER" -H "$@"
+            }
           else
             export RUNNER_USER="$(whoami)"
             export RUNNER_HOME="${HOME:-/home/$RUNNER_USER}"
-            run_as_user() { "$@"; }
+            echo "Setting up for non-root user: $RUNNER_USER"
+            run_as_user() { 
+              echo "Running as $RUNNER_USER: $*"
+              "$@"
+            }
           fi
+          
+          echo "Final environment:"
+          echo "RUNNER_USER=$RUNNER_USER"
+          echo "RUNNER_HOME=$RUNNER_HOME"
+          echo "=== End Environment Setup ==="
           
           cd "${{ github.workspace }}/${{ matrix.application }}-${{ github.run_id }}-arm64"
           echo "🚀 Starting installation of ${{ matrix.application }} [ARM64]..."
           echo "📁 Working in: $(pwd)"
           
+          # Check if orodc exists and is executable
+          echo "Checking OroDC binary:"
+          ls -la /home/linuxbrew/.linuxbrew/bin/orodc || echo "OroDC binary not found!"
+          
           # Install the application
-          run_as_user /home/linuxbrew/.linuxbrew/bin/orodc install
+          echo "Installing application..."
+          if ! run_as_user env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc install; then
+            echo "❌ OroDC install failed!"
+            echo "Checking OroDC status..."
+            run_as_user env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc --version || echo "OroDC version check failed"
+            exit 1
+          fi
           
           # Start services
-          run_as_user /home/linuxbrew/.linuxbrew/bin/orodc up -d
+          echo "Starting services..."
+          if ! run_as_user env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc up -d; then
+            echo "❌ OroDC up failed!"
+            echo "Checking docker status..."
+            docker --version || echo "Docker not available"
+            run_as_user docker compose version || echo "Docker Compose not available"
+            exit 1
+          fi
           
           echo "✅ Installation completed [ARM64]"
 
@@ -560,14 +702,14 @@ jobs:
           # Wait up to 10 minutes for services to be ready
           if [ "$(whoami)" = "root" ]; then
             timeout 600 bash -c '
-              while ! sudo -u github-runner -H /home/linuxbrew/.linuxbrew/bin/orodc ps | grep -q "Up"; do
+              while ! sudo -u github-runner -H env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc ps | grep -q "Up"; do
                 echo "Waiting for services..."
                 sleep 10
               done
             '
           else
             timeout 600 bash -c '
-              while ! /home/linuxbrew/.linuxbrew/bin/orodc ps | grep -q "Up"; do
+              while ! env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc ps | grep -q "Up"; do
                 echo "Waiting for services..."
                 sleep 10
               done
@@ -615,15 +757,15 @@ jobs:
           
           # Check container status
           echo "📋 Container status:"
-          run_as_user /home/linuxbrew/.linuxbrew/bin/orodc ps
+          run_as_user env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc ps
           
           # Check PHP version
           echo "🐘 PHP version:"
-          run_as_user /home/linuxbrew/.linuxbrew/bin/orodc php --version
+          run_as_user env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc php --version
           
           # Check database connection
           echo "🗄️  Database connection:"
-          run_as_user /home/linuxbrew/.linuxbrew/bin/orodc psql -c "SELECT version();" || echo "Database check failed"
+          run_as_user env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc psql -c "SELECT version();" || echo "Database check failed"
           
           echo "✅ Health checks completed [ARM64]"
 
@@ -639,9 +781,9 @@ jobs:
           
           cd "${{ github.workspace }}/${{ matrix.application }}-${{ github.run_id }}-arm64" 2>/dev/null || true
           echo "🧹 Cleaning up after failure [ARM64]..."
-          run_as_user /home/linuxbrew/.linuxbrew/bin/orodc logs --tail=50 || true
-          run_as_user /home/linuxbrew/.linuxbrew/bin/orodc down --remove-orphans || true
-          run_as_user /home/linuxbrew/.linuxbrew/bin/orodc purge || true
+          run_as_user env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc logs --tail=50 || true
+          run_as_user env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc down --remove-orphans || true
+          run_as_user env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc purge || true
 
       - name: Cleanup on success
         if: success()
@@ -655,8 +797,8 @@ jobs:
           
           cd "${{ github.workspace }}/${{ matrix.application }}-${{ github.run_id }}-arm64" 2>/dev/null || true
           echo "🧹 Cleaning up after success [ARM64]..."
-          run_as_user /home/linuxbrew/.linuxbrew/bin/orodc down --remove-orphans || true
-          run_as_user /home/linuxbrew/.linuxbrew/bin/orodc purge || true
+          run_as_user env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc down --remove-orphans || true
+          run_as_user env DEBUG=1 /home/linuxbrew/.linuxbrew/bin/orodc purge || true
 
   test-summary:
     needs: [test-installation-x64, test-installation-arm64]

--- a/Formula/docker-compose-oroplatform.rb
+++ b/Formula/docker-compose-oroplatform.rb
@@ -2,7 +2,7 @@ class DockerComposeOroplatform < Formula
   desc "CLI tool to run ORO applications locally or on a server"
   homepage "https://github.com/digitalspacestdio/homebrew-docker-compose-oroplatform"
   url "file:///dev/null"
-  version "0.11.10"
+  version "0.11.11"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
   def self.aliases


### PR DESCRIPTION
- Enable DEBUG=1 environment variable for all OroDC command executions
- Add debug logging to install, start, status check, and cleanup operations
- Include DEBUG flag in both direct commands and bash timeout loops
- Update both X64 and ARM64 workflow jobs consistently
- Increment formula version to 0.11.11

This provides detailed debug output from OroDC to help troubleshoot self-hosted runner issues and command failures.