### PR TITLE
fix: Add github-runner user to docker group for Docker access

### DIFF
--- a/.github/workflows/test-oro-installations.yml
+++ b/.github/workflows/test-oro-installations.yml
@@ -73,6 +73,14 @@ jobs:
               echo "Created github-runner user"
             fi
             
+            # Add github-runner to docker group for Docker access
+            if getent group docker >/dev/null 2>&1; then
+              usermod -aG docker github-runner
+              echo "Added github-runner to docker group"
+            else
+              echo "Warning: docker group not found - Docker may not be properly installed"
+            fi
+            
             # Set up environment for github-runner user
             export RUNNER_USER="github-runner"
             export RUNNER_HOME="/home/github-runner"
@@ -467,6 +475,14 @@ jobs:
             if ! id "github-runner" &>/dev/null; then
               useradd -m -s /bin/bash github-runner
               echo "Created github-runner user"
+            fi
+            
+            # Add github-runner to docker group for Docker access
+            if getent group docker >/dev/null 2>&1; then
+              usermod -aG docker github-runner
+              echo "Added github-runner to docker group"
+            else
+              echo "Warning: docker group not found - Docker may not be properly installed"
             fi
             
             # Set up environment for github-runner user

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,45 @@ git push -u origin feature/my-feature
 2. Create rollback PR if needed
 3. Follow proper branch workflow for future changes
 
+### 🔄 **CRITICAL: New Changes After Push Rule**
+
+**⛔ NEVER add new changes to already pushed branches:**
+
+If you've already pushed a branch and want to add MORE changes, **ALWAYS**:
+
+1. **Update from upstream first:**
+   ```bash
+   git fetch --all
+   git checkout master
+   git pull main master
+   git push origin master
+   ```
+
+2. **Create NEW branch for additional changes:**
+   ```bash
+   git checkout -b fix/additional-improvements
+   # Make your new changes
+   git commit -m "Additional improvements"
+   git push -u origin fix/additional-improvements
+   ```
+
+**⛔ NEVER do this after push:**
+```bash
+# ❌ WRONG: Adding to already pushed branch
+git checkout existing-pushed-branch
+# make changes
+git commit -m "more changes" 
+git push  # ❌ This creates messy history!
+```
+
+**Why this rule exists:**
+- 🔄 **Clean History**: Each branch represents one logical change
+- 🔍 **Clear Review**: Easier to review focused changes
+- 🛡️ **Safer Merges**: Avoid complex merge conflicts
+- 📝 **Better Tracking**: Each PR has clear scope and purpose
+
+**Exception:** Only add to pushed branches if explicitly fixing issues in the SAME Pull Request discussion.
+
 ### 📛 If you accidentally worked in master:
 
 1. **Create a branch from current state:**

--- a/Formula/docker-compose-oroplatform.rb
+++ b/Formula/docker-compose-oroplatform.rb
@@ -2,7 +2,7 @@ class DockerComposeOroplatform < Formula
   desc "CLI tool to run ORO applications locally or on a server"
   homepage "https://github.com/digitalspacestdio/homebrew-docker-compose-oroplatform"
   url "file:///dev/null"
-  version "0.11.13"
+  version "0.11.16"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
   def self.aliases


### PR DESCRIPTION
- Add usermod -aG docker github-runner when creating user
- Check if docker group exists before adding user
- Add warning if docker group is not found
- This fixes permission denied errors when accessing Docker socket

Documentation updates:
- Add critical rule to AGENTS.md about new changes after push
- Require creating NEW branches for additional changes after push
- Prevent messy git history and complex merge conflicts
- Increment formula version to 0.11.16

This resolves the issue where github-runner user couldn't access Docker: 'permission denied while trying to connect to the Docker daemon socket'