### PR TITLE
fix: Resolve stdout contamination in resolve_bin function

### DIFF
--- a/Formula/docker-compose-oroplatform.rb
+++ b/Formula/docker-compose-oroplatform.rb
@@ -2,7 +2,7 @@ class DockerComposeOroplatform < Formula
   desc "CLI tool to run ORO applications locally or on a server"
   homepage "https://github.com/digitalspacestdio/homebrew-docker-compose-oroplatform"
   url "file:///dev/null"
-  version "0.11.16"
+  version "0.11.17"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
   def self.aliases

--- a/bin/orodc
+++ b/bin/orodc
@@ -72,7 +72,7 @@ resolve_bin() {
         if [[ -x "$brew_path" ]]; then
           found_path="$brew_path"
           msg_warning "$bin_name found at $found_path but not in PATH"
-          echo "   Add to PATH: export PATH=\"$(dirname "$found_path"):\$PATH\""
+          echo "   Add to PATH: export PATH=\"$(dirname "$found_path"):\$PATH\"" >&2
           echo "$found_path"
           return 0
         fi


### PR DESCRIPTION
- Add missing >&2 redirect for PATH instruction message
- This prevents diagnostic messages from being captured in BREW_BIN variable
- Ensures only the binary path is returned in stdout
- Increment formula version to 0.11.17

This fixes the issue where BREW_BIN contained multiline text:
'   Add to PATH: export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
/home/linuxbrew/.linuxbrew/bin/brew'

Now BREW_BIN will contain only:
'/home/linuxbrew/.linuxbrew/bin/brew'