### PR TITLE
optimize: Use GitHub-hosted runners for lightweight tasks

### DIFF
--- a/.github/workflows/build-docker-nginx.yml
+++ b/.github/workflows/build-docker-nginx.yml
@@ -65,7 +65,7 @@ jobs:
   create-nginx-manifest:
     name: Create multi-arch manifest
     needs: [build-nginx-amd64, build-nginx-arm64]
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     steps:
       - name: Log in to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/build-docker-php-node-symfony.yml
+++ b/.github/workflows/build-docker-php-node-symfony.yml
@@ -85,7 +85,7 @@ jobs:
   create-7-4-manifest:
     name: Create PHP 7.4 multi-arch manifests
     needs: [build-7-4-amd64, build-7-4-arm64]
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         php:      ["7.4"]
@@ -179,7 +179,7 @@ jobs:
   create-8-x-manifest:
     name: Create PHP 8.x multi-arch manifests
     needs: [build-8-x-amd64, build-8-x-arm64]
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         php:      ["8.1","8.2","8.3","8.4"]
@@ -273,7 +273,7 @@ jobs:
   create-8-5-manifest:
     name: Create PHP 8.5 multi-arch manifests
     needs: [build-8-5-amd64, build-8-5-arm64]
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         php:      ["8.5"]

--- a/.github/workflows/test-oro-installations.yml
+++ b/.github/workflows/test-oro-installations.yml
@@ -838,7 +838,7 @@ jobs:
 
   test-summary:
     needs: [test-installation-x64, test-installation-arm64]
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Test Summary

--- a/Formula/docker-compose-oroplatform.rb
+++ b/Formula/docker-compose-oroplatform.rb
@@ -2,7 +2,7 @@ class DockerComposeOroplatform < Formula
   desc "CLI tool to run ORO applications locally or on a server"
   homepage "https://github.com/digitalspacestdio/homebrew-docker-compose-oroplatform"
   url "file:///dev/null"
-  version "0.11.17"
+  version "0.11.18"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
   def self.aliases


### PR DESCRIPTION
Move lightweight jobs to ubuntu-latest to optimize self-hosted runner usage:

📋 Moved to GitHub-hosted runners (ubuntu-latest):
- test-summary: Only aggregates test results, no heavy operations
- create-nginx-manifest: Simply combines already built Docker images
- create-7-4-manifest: Creates multi-arch manifests for PHP 7.4 images
- create-8-x-manifest: Creates multi-arch manifests for PHP 8.x images
- create-8-5-manifest: Creates multi-arch manifests for PHP 8.5 images

🏗️ Kept on self-hosted runners:
- All build-*-amd64/arm64 jobs: Require specific architectures for Docker builds
- test-installation-*: Need specialized OroPlatform testing environment

Benefits:
- ⚡ Reduced load on self-hosted runners
- 💰 Cost optimization (GitHub-hosted runners are free for public repos)
- 🚀 Better resource allocation for heavy tasks
- 📦 Increment formula version to 0.11.18

Manifest creation jobs only run 'docker buildx imagetools create' commands which are very lightweight and don't require specific architecture.