### PR TITLE
Add workflow_dispatch trigger with PHP version selection

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -7,6 +7,16 @@ on:
       - 'compose/docker/php/**'
       - 'compose/docker/php-node-symfony/**'
   workflow_dispatch:
+    inputs:
+      php_versions:
+        description: 'PHP versions to build (comma-separated: 7.4,8.1,8.2,8.3,8.4,8.5 or "all")'
+        required: false
+        default: 'all'
+      skip_tests:
+        description: 'Skip test workflow trigger'
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read


### PR DESCRIPTION
- Enable manual workflow runs from GitHub UI
- Add input to select specific PHP versions or build all
- Add option to skip test workflow trigger
- Useful for testing and selective rebuilds