### PR TITLE
Fix workflow_dispatch to enable manual runs

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -12,6 +12,11 @@ on:
         description: 'PHP versions to build (comma-separated: 7.4,8.1,8.2,8.3,8.4,8.5 or "all")'
         required: false
         default: 'all'
+    inputs:
+      php_versions:
+        description: 'PHP versions to build (comma-separated: 7.4,8.1,8.2,8.3,8.4,8.5 or "all")'
+        required: false
+        default: 'all'
       skip_tests:
         description: 'Skip test workflow trigger'
         type: boolean


### PR DESCRIPTION
- Add input parameters to workflow_dispatch trigger
- Without inputs, GitHub doesn't show 'Run workflow' button
- Add php_versions input for selective builds
- Matches behavior from old workflow before consolidation