### PR TITLE
fix: remove Python 2 from PHP 8.x build scripts

### DIFF
--- a/compose/docker/php-node-symfony/build8.1.sh
+++ b/compose/docker/php-node-symfony/build8.1.sh
@@ -63,9 +63,6 @@ apk add --no-cache \
 apk add --no-cache sudo
 echo "developer ALL=(ALL) ALL" >> /etc/sudoers
 
-# Install Python 2 for Node.js modules
-apk add --no-cache python2
-
 # Install and configure Zsh + Starship
 apk add --no-cache zsh
 

--- a/compose/docker/php-node-symfony/build8.2.sh
+++ b/compose/docker/php-node-symfony/build8.2.sh
@@ -63,9 +63,6 @@ apk add --no-cache \
 apk add --no-cache sudo
 echo "developer ALL=(ALL) ALL" >> /etc/sudoers
 
-# Install Python 2 for Node.js modules
-apk add --no-cache python2
-
 # Install and configure Zsh + Starship
 apk add --no-cache zsh
 

--- a/compose/docker/php-node-symfony/build8.3.sh
+++ b/compose/docker/php-node-symfony/build8.3.sh
@@ -63,9 +63,6 @@ apk add --no-cache \
 apk add --no-cache sudo
 echo "developer ALL=(ALL) ALL" >> /etc/sudoers
 
-# Install Python 2 for Node.js modules
-apk add --no-cache python2
-
 # Install and configure Zsh + Starship
 apk add --no-cache zsh
 

--- a/compose/docker/php-node-symfony/build8.4.sh
+++ b/compose/docker/php-node-symfony/build8.4.sh
@@ -63,9 +63,6 @@ apk add --no-cache \
 apk add --no-cache sudo
 echo "developer ALL=(ALL) ALL" >> /etc/sudoers
 
-# Install Python 2 for Node.js modules
-apk add --no-cache python2
-
 # Install and configure Zsh + Starship
 apk add --no-cache zsh
 

--- a/compose/docker/php-node-symfony/build8.5.sh
+++ b/compose/docker/php-node-symfony/build8.5.sh
@@ -63,9 +63,6 @@ apk add --no-cache \
 apk add --no-cache sudo
 echo "developer ALL=(ALL) ALL" >> /etc/sudoers
 
-# Install Python 2 for Node.js modules
-apk add --no-cache python2
-
 # Install and configure Zsh + Starship
 apk add --no-cache zsh
 


### PR DESCRIPTION
Python 2 is only needed for PHP 7.4 to support legacy node-sass compilation.

Alpine 3.18+ (used by PHP 8.1-8.5) removed python2 package. Modern projects use Dart Sass which doesn't require Python 2.

Changes:
- Removed 'apk add --no-cache python2' from build8.1.sh
- Removed 'apk add --no-cache python2' from build8.2.sh
- Removed 'apk add --no-cache python2' from build8.3.sh
- Removed 'apk add --no-cache python2' from build8.4.sh
- Removed 'apk add --no-cache python2' from build8.5.sh
- Kept in build7.4.sh (Alpine 3.16 supports it, needed for node-sass)