### PR TITLE
feat: skip docker image rebuild if content hash matches

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -71,8 +71,36 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
       
+      # Check if image needs rebuild (reduces GHCR API calls)
+      - name: Check if image needs rebuild
+        id: check-rebuild
+        run: |
+          IMAGE="ghcr.io/${{ github.repository_owner }}/orodc-php:7.4-alpine-${{ matrix.arch_name }}"
+          
+          # Calculate hash of files affecting this version
+          HASH=$(cat compose/docker/php/Dockerfile.7.4.alpine | sha256sum | cut -d' ' -f1)
+          echo "hash=${HASH}" >> $GITHUB_OUTPUT
+          
+          # Check if image exists with same hash
+          if docker pull --quiet ${IMAGE} 2>/dev/null; then
+            EXISTING_HASH=$(docker inspect ${IMAGE} --format '{{index .Config.Labels "build.hash"}}' 2>/dev/null || echo "")
+            
+            if [ "${EXISTING_HASH}" = "${HASH}" ]; then
+              echo "skip=true" >> $GITHUB_OUTPUT
+              echo "[SKIP] Image exists with matching hash: ${HASH}"
+              exit 0
+            else
+              echo "skip=false" >> $GITHUB_OUTPUT
+              echo "[BUILD] Hash changed: ${EXISTING_HASH:-none} -> ${HASH}"
+            fi
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "[BUILD] Image not found in registry"
+          fi
+      
       # Build with retry (handles Docker Hub rate limits)
       - name: Build PHP 7.4 Base (${{ matrix.arch_name }})
+        if: steps.check-rebuild.outputs.skip != 'true'
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 30
@@ -85,6 +113,9 @@ jobs:
               --tag ghcr.io/${{ github.repository_owner }}/orodc-php:7.4-alpine-${{ matrix.arch_name }} \
               --build-arg PHP_VERSION=7.4 \
               --build-arg COMPOSER_VERSION=2 \
+              --label "build.hash=${{ steps.check-rebuild.outputs.hash }}" \
+              --label "build.date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+              --label "build.commit=${{ github.sha }}" \
               --cache-from type=gha,scope=php-base-7.4-${{ matrix.arch }} \
               --cache-to type=gha,mode=max,scope=php-base-7.4-${{ matrix.arch }} \
               --load \
@@ -92,6 +123,7 @@ jobs:
       
       # Push with retry (handles network errors)
       - name: Push PHP 7.4 Base (${{ matrix.arch_name }})
+        if: steps.check-rebuild.outputs.skip != 'true'
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
@@ -141,8 +173,36 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
       
+      # Check if image needs rebuild (reduces GHCR API calls)
+      - name: Check if image needs rebuild
+        id: check-rebuild
+        run: |
+          IMAGE="ghcr.io/${{ github.repository_owner }}/orodc-php:${{ matrix.php }}-alpine-${{ matrix.arch_config.arch_name }}"
+          
+          # Calculate hash of files affecting this version
+          HASH=$(cat compose/docker/php/Dockerfile.${{ matrix.php }}.alpine | sha256sum | cut -d' ' -f1)
+          echo "hash=${HASH}" >> $GITHUB_OUTPUT
+          
+          # Check if image exists with same hash
+          if docker pull --quiet ${IMAGE} 2>/dev/null; then
+            EXISTING_HASH=$(docker inspect ${IMAGE} --format '{{index .Config.Labels "build.hash"}}' 2>/dev/null || echo "")
+            
+            if [ "${EXISTING_HASH}" = "${HASH}" ]; then
+              echo "skip=true" >> $GITHUB_OUTPUT
+              echo "[SKIP] Image exists with matching hash: ${HASH}"
+              exit 0
+            else
+              echo "skip=false" >> $GITHUB_OUTPUT
+              echo "[BUILD] Hash changed: ${EXISTING_HASH:-none} -> ${HASH}"
+            fi
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "[BUILD] Image not found in registry"
+          fi
+      
       # Build with retry (handles Docker Hub rate limits)
       - name: Build PHP ${{ matrix.php }} Base (${{ matrix.arch_config.arch_name }})
+        if: steps.check-rebuild.outputs.skip != 'true'
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 30
@@ -155,6 +215,9 @@ jobs:
               --tag ghcr.io/${{ github.repository_owner }}/orodc-php:${{ matrix.php }}-alpine-${{ matrix.arch_config.arch_name }} \
               --build-arg PHP_VERSION=${{ matrix.php }} \
               --build-arg COMPOSER_VERSION=2 \
+              --label "build.hash=${{ steps.check-rebuild.outputs.hash }}" \
+              --label "build.date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+              --label "build.commit=${{ github.sha }}" \
               --cache-from type=gha,scope=php-base-${{ matrix.php }}-${{ matrix.arch_config.arch }} \
               --cache-to type=gha,mode=max,scope=php-base-${{ matrix.php }}-${{ matrix.arch_config.arch }} \
               --load \
@@ -162,6 +225,7 @@ jobs:
       
       # Push with retry (handles network errors)
       - name: Push PHP ${{ matrix.php }} Base (${{ matrix.arch_config.arch_name }})
+        if: steps.check-rebuild.outputs.skip != 'true'
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
@@ -210,8 +274,36 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
       
+      # Check if image needs rebuild (reduces GHCR API calls)
+      - name: Check if image needs rebuild
+        id: check-rebuild
+        run: |
+          IMAGE="ghcr.io/${{ github.repository_owner }}/orodc-php:8.5-rc-alpine-${{ matrix.arch_name }}"
+          
+          # Calculate hash of files affecting this version
+          HASH=$(cat compose/docker/php/Dockerfile.8.5.alpine | sha256sum | cut -d' ' -f1)
+          echo "hash=${HASH}" >> $GITHUB_OUTPUT
+          
+          # Check if image exists with same hash
+          if docker pull --quiet ${IMAGE} 2>/dev/null; then
+            EXISTING_HASH=$(docker inspect ${IMAGE} --format '{{index .Config.Labels "build.hash"}}' 2>/dev/null || echo "")
+            
+            if [ "${EXISTING_HASH}" = "${HASH}" ]; then
+              echo "skip=true" >> $GITHUB_OUTPUT
+              echo "[SKIP] Image exists with matching hash: ${HASH}"
+              exit 0
+            else
+              echo "skip=false" >> $GITHUB_OUTPUT
+              echo "[BUILD] Hash changed: ${EXISTING_HASH:-none} -> ${HASH}"
+            fi
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "[BUILD] Image not found in registry"
+          fi
+      
       # Build with retry (handles Docker Hub rate limits)
       - name: Build PHP 8.5-rc Base (${{ matrix.arch_name }})
+        if: steps.check-rebuild.outputs.skip != 'true'
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 30
@@ -224,6 +316,9 @@ jobs:
               --tag ghcr.io/${{ github.repository_owner }}/orodc-php:8.5-rc-alpine-${{ matrix.arch_name }} \
               --build-arg PHP_VERSION=8.5-rc \
               --build-arg COMPOSER_VERSION=2 \
+              --label "build.hash=${{ steps.check-rebuild.outputs.hash }}" \
+              --label "build.date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+              --label "build.commit=${{ github.sha }}" \
               --cache-from type=gha,scope=php-base-8.5-${{ matrix.arch }} \
               --cache-to type=gha,mode=max,scope=php-base-8.5-${{ matrix.arch }} \
               --load \
@@ -231,6 +326,7 @@ jobs:
       
       # Push with retry (handles network errors)
       - name: Push PHP 8.5-rc Base (${{ matrix.arch_name }})
+        if: steps.check-rebuild.outputs.skip != 'true'
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
@@ -354,8 +450,36 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
       
+      # Check if image needs rebuild (reduces GHCR API calls)
+      - name: Check if image needs rebuild
+        id: check-rebuild
+        run: |
+          IMAGE="ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:7.4-alpine-${{ matrix.arch_name }}"
+          
+          # Calculate hash of files affecting this version
+          HASH=$(cat compose/docker/php-node-symfony/Dockerfile.7.4.alpine compose/docker/php-node-symfony/build7.4.sh 2>/dev/null | sha256sum | cut -d' ' -f1)
+          echo "hash=${HASH}" >> $GITHUB_OUTPUT
+          
+          # Check if image exists with same hash
+          if docker pull --quiet ${IMAGE} 2>/dev/null; then
+            EXISTING_HASH=$(docker inspect ${IMAGE} --format '{{index .Config.Labels "build.hash"}}' 2>/dev/null || echo "")
+            
+            if [ "${EXISTING_HASH}" = "${HASH}" ]; then
+              echo "skip=true" >> $GITHUB_OUTPUT
+              echo "[SKIP] Image exists with matching hash: ${HASH}"
+              exit 0
+            else
+              echo "skip=false" >> $GITHUB_OUTPUT
+              echo "[BUILD] Hash changed: ${EXISTING_HASH:-none} -> ${HASH}"
+            fi
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "[BUILD] Image not found in registry"
+          fi
+      
       # Build with retry
       - name: Build PHP+Node 7.4 (${{ matrix.arch_name }})
+        if: steps.check-rebuild.outputs.skip != 'true'
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 30
@@ -366,6 +490,9 @@ jobs:
               --file compose/docker/php-node-symfony/Dockerfile.7.4.alpine \
               --platform ${{ matrix.platform }} \
               --tag ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:7.4-alpine-${{ matrix.arch_name }} \
+              --label "build.hash=${{ steps.check-rebuild.outputs.hash }}" \
+              --label "build.date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+              --label "build.commit=${{ github.sha }}" \
               --cache-from type=gha,scope=php-node-7.4-${{ matrix.arch }} \
               --cache-to type=gha,mode=max,scope=php-node-7.4-${{ matrix.arch }} \
               --load \
@@ -373,6 +500,7 @@ jobs:
       
       # Push with retry
       - name: Push PHP+Node 7.4 (${{ matrix.arch_name }})
+        if: steps.check-rebuild.outputs.skip != 'true'
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
@@ -423,8 +551,36 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
       
+      # Check if image needs rebuild (reduces GHCR API calls)
+      - name: Check if image needs rebuild
+        id: check-rebuild
+        run: |
+          IMAGE="ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-alpine-${{ matrix.arch_config.arch_name }}"
+          
+          # Calculate hash of files affecting this version
+          HASH=$(cat compose/docker/php-node-symfony/Dockerfile.${{ matrix.php }}.alpine compose/docker/php-node-symfony/build${{ matrix.php }}.sh 2>/dev/null | sha256sum | cut -d' ' -f1)
+          echo "hash=${HASH}" >> $GITHUB_OUTPUT
+          
+          # Check if image exists with same hash
+          if docker pull --quiet ${IMAGE} 2>/dev/null; then
+            EXISTING_HASH=$(docker inspect ${IMAGE} --format '{{index .Config.Labels "build.hash"}}' 2>/dev/null || echo "")
+            
+            if [ "${EXISTING_HASH}" = "${HASH}" ]; then
+              echo "skip=true" >> $GITHUB_OUTPUT
+              echo "[SKIP] Image exists with matching hash: ${HASH}"
+              exit 0
+            else
+              echo "skip=false" >> $GITHUB_OUTPUT
+              echo "[BUILD] Hash changed: ${EXISTING_HASH:-none} -> ${HASH}"
+            fi
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "[BUILD] Image not found in registry"
+          fi
+      
       # Build with retry
       - name: Build PHP+Node ${{ matrix.php }} (${{ matrix.arch_config.arch_name }})
+        if: steps.check-rebuild.outputs.skip != 'true'
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 30
@@ -435,6 +591,9 @@ jobs:
               --file compose/docker/php-node-symfony/Dockerfile.${{ matrix.php }}.alpine \
               --platform ${{ matrix.arch_config.platform }} \
               --tag ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-alpine-${{ matrix.arch_config.arch_name }} \
+              --label "build.hash=${{ steps.check-rebuild.outputs.hash }}" \
+              --label "build.date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+              --label "build.commit=${{ github.sha }}" \
               --cache-from type=gha,scope=php-node-${{ matrix.php }}-${{ matrix.arch_config.arch }} \
               --cache-to type=gha,mode=max,scope=php-node-${{ matrix.php }}-${{ matrix.arch_config.arch }} \
               --load \
@@ -442,6 +601,7 @@ jobs:
       
       # Push with retry
       - name: Push PHP+Node ${{ matrix.php }} (${{ matrix.arch_config.arch_name }})
+        if: steps.check-rebuild.outputs.skip != 'true'
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
@@ -491,8 +651,36 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
       
+      # Check if image needs rebuild (reduces GHCR API calls)
+      - name: Check if image needs rebuild
+        id: check-rebuild
+        run: |
+          IMAGE="ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:8.5-alpine-${{ matrix.arch_name }}"
+          
+          # Calculate hash of files affecting this version
+          HASH=$(cat compose/docker/php-node-symfony/Dockerfile.8.5.alpine compose/docker/php-node-symfony/build8.5.sh 2>/dev/null | sha256sum | cut -d' ' -f1)
+          echo "hash=${HASH}" >> $GITHUB_OUTPUT
+          
+          # Check if image exists with same hash
+          if docker pull --quiet ${IMAGE} 2>/dev/null; then
+            EXISTING_HASH=$(docker inspect ${IMAGE} --format '{{index .Config.Labels "build.hash"}}' 2>/dev/null || echo "")
+            
+            if [ "${EXISTING_HASH}" = "${HASH}" ]; then
+              echo "skip=true" >> $GITHUB_OUTPUT
+              echo "[SKIP] Image exists with matching hash: ${HASH}"
+              exit 0
+            else
+              echo "skip=false" >> $GITHUB_OUTPUT
+              echo "[BUILD] Hash changed: ${EXISTING_HASH:-none} -> ${HASH}"
+            fi
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "[BUILD] Image not found in registry"
+          fi
+      
       # Build with retry
       - name: Build PHP+Node 8.5-rc (${{ matrix.arch_name }})
+        if: steps.check-rebuild.outputs.skip != 'true'
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 30
@@ -503,6 +691,9 @@ jobs:
               --file compose/docker/php-node-symfony/Dockerfile.8.5.alpine \
               --platform ${{ matrix.platform }} \
               --tag ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:8.5-alpine-${{ matrix.arch_name }} \
+              --label "build.hash=${{ steps.check-rebuild.outputs.hash }}" \
+              --label "build.date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+              --label "build.commit=${{ github.sha }}" \
               --cache-from type=gha,scope=php-node-8.5-${{ matrix.arch }} \
               --cache-to type=gha,mode=max,scope=php-node-8.5-${{ matrix.arch }} \
               --load \
@@ -510,6 +701,7 @@ jobs:
       
       # Push with retry
       - name: Push PHP+Node 8.5-rc (${{ matrix.arch_name }})
+        if: steps.check-rebuild.outputs.skip != 'true'
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10

--- a/Formula/docker-compose-oroplatform.rb
+++ b/Formula/docker-compose-oroplatform.rb
@@ -2,7 +2,7 @@ class DockerComposeOroplatform < Formula
   desc "CLI tool to run ORO applications locally or on a server"
   homepage "https://github.com/digitalspacestdio/homebrew-docker-compose-oroplatform"
   url "file:///dev/null"
-  version "0.11.39"
+  version "0.11.40"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
   def self.aliases


### PR DESCRIPTION
- Add content hash calculation for Docker images before build
- Compare hash with existing image label to skip unnecessary rebuilds
- Reduces GHCR API calls and rate limiting errors
- Applies to all PHP base images (7.4, 8.1-8.5)
- Applies to all PHP+Node images (7.4, 8.1-8.5)
- Add build metadata labels: build.hash, build.date, build.commit
- Skip both build and push steps when image content unchanged
- Version bump: 0.11.39 -> 0.11.40