### PR TITLE
refactor: unify PHP+Node build jobs and optimize manifests

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -222,10 +222,7 @@ jobs:
   create-php-base-manifests:
     name: PHP ${{ matrix.version }} (Manifest)
     needs: [build-php-base]
-    runs-on:
-      - self-hosted
-      - Linux
-      - X64
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         version: ["7.4", "8.1", "8.2", "8.3", "8.4", "8.5"]
@@ -247,23 +244,94 @@ jobs:
   # STAGE 3: FINAL PHP+NODE.JS IMAGES
   # ========================================
   
-  # PHP+Node.js 7.4 (Legacy)
-  build-php-node-7-4:
-    name: PHP+Node 7.4 (${{ matrix.arch_name }})
+  build-php-node:
+    name: PHP+Node ${{ matrix.config.version }} (${{ matrix.config.arch_name }})
     needs: [create-php-base-manifests]
     runs-on:
       - self-hosted
       - Linux
-      - ${{ matrix.arch }}
+      - ${{ matrix.config.arch }}
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 6
       matrix:
-        include:
-          - arch: X64
+        config:
+          # PHP+Node 7.4
+          - version: "7.4"
+            tag: "7.4"
+            dockerfile: "7.4"
+            arch: X64
             arch_name: amd64
             platform: linux/amd64
-          - arch: ARM64
+          - version: "7.4"
+            tag: "7.4"
+            dockerfile: "7.4"
+            arch: ARM64
+            arch_name: arm64
+            platform: linux/arm64
+          # PHP+Node 8.1
+          - version: "8.1"
+            tag: "8.1"
+            dockerfile: "8.1"
+            arch: X64
+            arch_name: amd64
+            platform: linux/amd64
+          - version: "8.1"
+            tag: "8.1"
+            dockerfile: "8.1"
+            arch: ARM64
+            arch_name: arm64
+            platform: linux/arm64
+          # PHP+Node 8.2
+          - version: "8.2"
+            tag: "8.2"
+            dockerfile: "8.2"
+            arch: X64
+            arch_name: amd64
+            platform: linux/amd64
+          - version: "8.2"
+            tag: "8.2"
+            dockerfile: "8.2"
+            arch: ARM64
+            arch_name: arm64
+            platform: linux/arm64
+          # PHP+Node 8.3
+          - version: "8.3"
+            tag: "8.3"
+            dockerfile: "8.3"
+            arch: X64
+            arch_name: amd64
+            platform: linux/amd64
+          - version: "8.3"
+            tag: "8.3"
+            dockerfile: "8.3"
+            arch: ARM64
+            arch_name: arm64
+            platform: linux/arm64
+          # PHP+Node 8.4
+          - version: "8.4"
+            tag: "8.4"
+            dockerfile: "8.4"
+            arch: X64
+            arch_name: amd64
+            platform: linux/amd64
+          - version: "8.4"
+            tag: "8.4"
+            dockerfile: "8.4"
+            arch: ARM64
+            arch_name: arm64
+            platform: linux/arm64
+          # PHP+Node 8.5
+          - version: "8.5"
+            tag: "8.5"
+            dockerfile: "8.5"
+            arch: X64
+            arch_name: amd64
+            platform: linux/amd64
+          - version: "8.5"
+            tag: "8.5"
+            dockerfile: "8.5"
+            arch: ARM64
             arch_name: arm64
             platform: linux/arm64
     steps:
@@ -292,10 +360,10 @@ jobs:
       - name: Check if image needs rebuild
         id: check-rebuild
         run: |
-          IMAGE="ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:7.4-alpine-${{ matrix.arch_name }}"
+          IMAGE="ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.config.tag }}-alpine-${{ matrix.config.arch_name }}"
           
           # Calculate hash of files affecting this version
-          HASH=$(cat compose/docker/php-node-symfony/Dockerfile.7.4.alpine compose/docker/php-node-symfony/build7.4.sh 2>/dev/null | sha256sum | cut -d' ' -f1)
+          HASH=$(cat compose/docker/php-node-symfony/Dockerfile.${{ matrix.config.dockerfile }}.alpine compose/docker/php-node-symfony/build${{ matrix.config.dockerfile }}.sh 2>/dev/null | sha256sum | cut -d' ' -f1)
           echo "hash=${HASH}" >> $GITHUB_OUTPUT
           
           # Check if image exists with same hash
@@ -316,7 +384,7 @@ jobs:
           fi
       
       # Build with retry
-      - name: Build PHP+Node 7.4 (${{ matrix.arch_name }})
+      - name: Build PHP+Node ${{ matrix.config.version }} (${{ matrix.config.arch_name }})
         if: steps.check-rebuild.outputs.skip != 'true'
         uses: nick-invision/retry@v2
         with:
@@ -325,19 +393,19 @@ jobs:
           retry_wait_seconds: 20
           command: |
             docker buildx build \
-              --file compose/docker/php-node-symfony/Dockerfile.7.4.alpine \
-              --platform ${{ matrix.platform }} \
-              --tag ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:7.4-alpine-${{ matrix.arch_name }} \
+              --file compose/docker/php-node-symfony/Dockerfile.${{ matrix.config.dockerfile }}.alpine \
+              --platform ${{ matrix.config.platform }} \
+              --tag ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.config.tag }}-alpine-${{ matrix.config.arch_name }} \
               --label "build.hash=${{ steps.check-rebuild.outputs.hash }}" \
               --label "build.date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
               --label "build.commit=${{ github.sha }}" \
-              --cache-from type=gha,scope=php-node-7.4-${{ matrix.arch }} \
-              --cache-to type=gha,mode=max,scope=php-node-7.4-${{ matrix.arch }} \
+              --cache-from type=gha,scope=php-node-${{ matrix.config.tag }}-${{ matrix.config.arch }} \
+              --cache-to type=gha,mode=max,scope=php-node-${{ matrix.config.tag }}-${{ matrix.config.arch }} \
               --load \
               compose/docker/php-node-symfony
       
       # Push with retry
-      - name: Push PHP+Node 7.4 (${{ matrix.arch_name }})
+      - name: Push PHP+Node ${{ matrix.config.version }} (${{ matrix.config.arch_name }})
         if: steps.check-rebuild.outputs.skip != 'true'
         uses: nick-invision/retry@v2
         with:
@@ -345,265 +413,19 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 20
           command: |
-            docker push ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:7.4-alpine-${{ matrix.arch_name }}
-
-  # PHP+Node.js 8.x (Stable: 8.1, 8.2, 8.3, 8.4)
-  build-php-node-8-x:
-    name: PHP+Node ${{ matrix.php }} (${{ matrix.arch_config.arch_name }})
-    needs: [create-php-base-manifests]
-    runs-on:
-      - self-hosted
-      - Linux
-      - ${{ matrix.arch_config.arch }}
-    strategy:
-      fail-fast: false
-      max-parallel: 4
-      matrix:
-        php: ["8.1", "8.2", "8.3", "8.4"]
-        arch_config:
-          - arch: X64
-            arch_name: amd64
-            platform: linux/amd64
-          - arch: ARM64
-            arch_name: arm64
-            platform: linux/arm64
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      
-      # Login to Docker Hub
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-        continue-on-error: true
-      
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
-      
-      # Check if image needs rebuild (reduces GHCR API calls)
-      - name: Check if image needs rebuild
-        id: check-rebuild
-        run: |
-          IMAGE="ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-alpine-${{ matrix.arch_config.arch_name }}"
-          
-          # Calculate hash of files affecting this version
-          HASH=$(cat compose/docker/php-node-symfony/Dockerfile.${{ matrix.php }}.alpine compose/docker/php-node-symfony/build${{ matrix.php }}.sh 2>/dev/null | sha256sum | cut -d' ' -f1)
-          echo "hash=${HASH}" >> $GITHUB_OUTPUT
-          
-          # Check if image exists with same hash
-          if docker pull --quiet "${IMAGE}" 2>/dev/null; then
-            EXISTING_HASH=$(docker inspect "${IMAGE}" --format '{{index .Config.Labels "build.hash"}}' 2>/dev/null || echo "")
-            
-            if [ "${EXISTING_HASH}" = "${HASH}" ]; then
-              echo "skip=true" >> $GITHUB_OUTPUT
-              echo "[SKIP] Image exists with matching hash: ${HASH}"
-              exit 0
-            else
-              echo "skip=false" >> $GITHUB_OUTPUT
-              echo "[BUILD] Hash changed: ${EXISTING_HASH:-none} -> ${HASH}"
-            fi
-          else
-            echo "skip=false" >> $GITHUB_OUTPUT
-            echo "[BUILD] Image not found in registry"
-          fi
-      
-      # Build with retry
-      - name: Build PHP+Node ${{ matrix.php }} (${{ matrix.arch_config.arch_name }})
-        if: steps.check-rebuild.outputs.skip != 'true'
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 30
-          max_attempts: 3
-          retry_wait_seconds: 20
-          command: |
-            docker buildx build \
-              --file compose/docker/php-node-symfony/Dockerfile.${{ matrix.php }}.alpine \
-              --platform ${{ matrix.arch_config.platform }} \
-              --tag ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-alpine-${{ matrix.arch_config.arch_name }} \
-              --label "build.hash=${{ steps.check-rebuild.outputs.hash }}" \
-              --label "build.date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
-              --label "build.commit=${{ github.sha }}" \
-              --cache-from type=gha,scope=php-node-${{ matrix.php }}-${{ matrix.arch_config.arch }} \
-              --cache-to type=gha,mode=max,scope=php-node-${{ matrix.php }}-${{ matrix.arch_config.arch }} \
-              --load \
-              compose/docker/php-node-symfony
-      
-      # Push with retry
-      - name: Push PHP+Node ${{ matrix.php }} (${{ matrix.arch_config.arch_name }})
-        if: steps.check-rebuild.outputs.skip != 'true'
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          retry_wait_seconds: 20
-          command: |
-            docker push ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-alpine-${{ matrix.arch_config.arch_name }}
-
-  # PHP+Node.js 8.5-rc (RC/Beta)
-  build-php-node-8-5:
-    name: PHP+Node 8.5 (${{ matrix.arch_name }})
-    needs: [create-php-base-manifests]
-    runs-on:
-      - self-hosted
-      - Linux
-      - ${{ matrix.arch }}
-    strategy:
-      fail-fast: false
-      max-parallel: 2
-      matrix:
-        include:
-          - arch: X64
-            arch_name: amd64
-            platform: linux/amd64
-          - arch: ARM64
-            arch_name: arm64
-            platform: linux/arm64
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      
-      # Login to Docker Hub
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-        continue-on-error: true
-      
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
-      
-      # Check if image needs rebuild (reduces GHCR API calls)
-      - name: Check if image needs rebuild
-        id: check-rebuild
-        run: |
-          IMAGE="ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:8.5-alpine-${{ matrix.arch_name }}"
-          
-          # Calculate hash of files affecting this version
-          HASH=$(cat compose/docker/php-node-symfony/Dockerfile.8.5.alpine compose/docker/php-node-symfony/build8.5.sh 2>/dev/null | sha256sum | cut -d' ' -f1)
-          echo "hash=${HASH}" >> $GITHUB_OUTPUT
-          
-          # Check if image exists with same hash
-          if docker pull --quiet "${IMAGE}" 2>/dev/null; then
-            EXISTING_HASH=$(docker inspect "${IMAGE}" --format '{{index .Config.Labels "build.hash"}}' 2>/dev/null || echo "")
-            
-            if [ "${EXISTING_HASH}" = "${HASH}" ]; then
-              echo "skip=true" >> $GITHUB_OUTPUT
-              echo "[SKIP] Image exists with matching hash: ${HASH}"
-              exit 0
-            else
-              echo "skip=false" >> $GITHUB_OUTPUT
-              echo "[BUILD] Hash changed: ${EXISTING_HASH:-none} -> ${HASH}"
-            fi
-          else
-            echo "skip=false" >> $GITHUB_OUTPUT
-            echo "[BUILD] Image not found in registry"
-          fi
-      
-      # Build with retry
-      - name: Build PHP+Node 8.5-rc (${{ matrix.arch_name }})
-        if: steps.check-rebuild.outputs.skip != 'true'
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 30
-          max_attempts: 3
-          retry_wait_seconds: 20
-          command: |
-            docker buildx build \
-              --file compose/docker/php-node-symfony/Dockerfile.8.5.alpine \
-              --platform ${{ matrix.platform }} \
-              --tag ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:8.5-alpine-${{ matrix.arch_name }} \
-              --label "build.hash=${{ steps.check-rebuild.outputs.hash }}" \
-              --label "build.date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
-              --label "build.commit=${{ github.sha }}" \
-              --cache-from type=gha,scope=php-node-8.5-${{ matrix.arch }} \
-              --cache-to type=gha,mode=max,scope=php-node-8.5-${{ matrix.arch }} \
-              --load \
-              compose/docker/php-node-symfony
-      
-      # Push with retry
-      - name: Push PHP+Node 8.5-rc (${{ matrix.arch_name }})
-        if: steps.check-rebuild.outputs.skip != 'true'
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          retry_wait_seconds: 20
-          command: |
-            docker push ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:8.5-alpine-${{ matrix.arch_name }}
+            docker push ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.config.tag }}-alpine-${{ matrix.config.arch_name }}
 
   # ========================================
   # STAGE 4: CREATE FINAL MULTI-ARCH MANIFESTS
   # ========================================
   
-  create-php-node-7-4-manifest:
-    name: PHP+Node 7.4 (Manifest)
-    needs: [build-php-node-7-4]
-    runs-on:
-      - self-hosted
-      - Linux
-      - X64
-    steps:
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Create and push manifest
-        run: |
-          docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:7.4-alpine \
-            ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:7.4-alpine-amd64 \
-            ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:7.4-alpine-arm64
-
-  create-php-node-8-x-manifests:
-    name: PHP+Node ${{ matrix.php }} (Manifest)
-    needs: [build-php-node-8-x]
-    runs-on:
-      - self-hosted
-      - Linux
-      - X64
+  create-php-node-manifests:
+    name: PHP+Node ${{ matrix.version }} (Manifest)
+    needs: [build-php-node]
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ["8.1", "8.2", "8.3", "8.4"]
-    steps:
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Create and push manifest for PHP+Node ${{ matrix.php }}
-        run: |
-          docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-alpine \
-            ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-alpine-amd64 \
-            ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.php }}-alpine-arm64
-
-  create-php-node-8-5-manifest:
-    name: PHP+Node 8.5 (Manifest)
-    needs: [build-php-node-8-5]
-    runs-on:
-      - self-hosted
-      - Linux
-      - X64
+        version: ["7.4", "8.1", "8.2", "8.3", "8.4", "8.5"]
     steps:
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -614,6 +436,6 @@ jobs:
       
       - name: Create and push manifest
         run: |
-          docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:8.5-alpine \
-            ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:8.5-alpine-amd64 \
-            ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:8.5-alpine-arm64
+          docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.version }}-alpine \
+            ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.version }}-alpine-amd64 \
+            ghcr.io/${{ github.repository_owner }}/orodc-php-node-symfony:${{ matrix.version }}-alpine-arm64

--- a/Formula/docker-compose-oroplatform.rb
+++ b/Formula/docker-compose-oroplatform.rb
@@ -2,7 +2,7 @@ class DockerComposeOroplatform < Formula
   desc "CLI tool to run ORO applications locally or on a server"
   homepage "https://github.com/digitalspacestdio/homebrew-docker-compose-oroplatform"
   url "file:///dev/null"
-  version "0.11.45"
+  version "0.11.46"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
   def self.aliases


### PR DESCRIPTION
- Merge build-php-node-7-4, build-php-node-8-x, build-php-node-8-5 into build-php-node
- Single matrix with all PHP+Node versions (7.4, 8.1-8.5)
- Merge 3 manifest jobs into create-php-node-manifests
- Move manifest creation to ubuntu-latest (GitHub runners)
  - Manifests only use registry API, don't need self-hosted
  - Frees up self-hosted runners for actual builds
- Same functionality, cleaner structure
- Reduces code duplication: -268 lines, +90 lines (net: -178 lines)
- Version bump: 0.11.45 -> 0.11.46