### PR TITLE
fix: update build-php-node job name to include Node.js version

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -221,7 +221,7 @@ jobs:
   # ========================================
   
   build-php-node:
-    name: PHP+Node ${{ matrix.php }} (${{ matrix.arch_name }})
+    name: PHP-${{ matrix.php }}+NODE-${{ matrix.node }} (${{ matrix.arch_name }})
     needs: [create-php-base-manifests]
     runs-on:
       - self-hosted


### PR DESCRIPTION
- Change job name from 'PHP+Node {php}' to 'PHP-{php}+NODE-{node}'
- Makes job names consistent with step names
- Example: 'PHP-8.4+NODE-22 (arm64)'