### PR TITLE
perf: remove max-parallel limits for faster builds

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -39,7 +39,6 @@ jobs:
       - ${{ matrix.arch }}
     strategy:
       fail-fast: false
-      max-parallel: 6
       matrix:
         include:
           # PHP 7.4
@@ -226,7 +225,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      max-parallel: 6
       matrix:
         include:
           # PHP 7.4 + Node 16, 18 + Composer 1, 2 (amd64)


### PR DESCRIPTION
- Remove max-parallel: 6 from build-php-base job
- Remove max-parallel: 6 from build-php-node job
- Allows unlimited parallel execution of matrix jobs
- Faster overall build time with GitHub-hosted runners