### PR TITLE
fix: use self-hosted ARM runners for native builds instead of QEMU

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -222,7 +222,10 @@ jobs:
   build-php-node:
     name: PHP-${{ matrix.php }}+NODE-${{ matrix.node }} (${{ matrix.arch_name }})
     needs: [create-php-base-manifests]
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - Linux
+      - ${{ matrix.arch }}
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -474,10 +477,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
-      # Set up QEMU for multi-arch builds (arm64 on amd64 host)
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3

--- a/Formula/docker-compose-oroplatform.rb
+++ b/Formula/docker-compose-oroplatform.rb
@@ -2,7 +2,7 @@ class DockerComposeOroplatform < Formula
   desc "CLI tool to run ORO applications locally or on a server"
   homepage "https://github.com/digitalspacestdio/homebrew-docker-compose-oroplatform"
   url "file:///dev/null"
-  version "0.11.48"
+  version "0.11.49"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
   def self.aliases


### PR DESCRIPTION
- Switch PHP+Node builds from ubuntu-latest to self-hosted runners
- Remove QEMU setup for multi-arch builds (no longer needed)
- Fixes ARM64 builds failing with Node.js binary incompatibility
- Each architecture now builds natively (X64 or ARM64)

Closes: ARM Docker build failures after GitHub Nodes migration