### PR TITLE
Add Docker Hub credentials rotation for rate limit distribution

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,5 +1,19 @@
 name: Build & Publish PHP Base and PHP+Node.js multi-arch images to GHCR
 
+# DOCKER HUB CREDENTIALS SETUP:
+# This workflow uses 4 Docker Hub accounts to distribute rate limits (200 pulls/6h per account = 800 total)
+# 
+# Required GitHub Secrets (8 total):
+#   DOCKERHUB_USERNAME_1, DOCKERHUB_TOKEN_1  - for PHP 7.4, 8.4
+#   DOCKERHUB_USERNAME_2, DOCKERHUB_TOKEN_2  - for PHP 8.1, 8.5
+#   DOCKERHUB_USERNAME_3, DOCKERHUB_TOKEN_3  - for PHP 8.2
+#   DOCKERHUB_USERNAME_4, DOCKERHUB_TOKEN_4  - for PHP 8.3
+#
+# Setup via GitHub CLI:
+#   gh secret set DOCKERHUB_USERNAME_1 -b "username1"
+#   gh secret set DOCKERHUB_TOKEN_1 -b "token1"
+#   (repeat for all 4 accounts)
+
 on:
   push:
     branches: [ master ]
@@ -111,12 +125,28 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
+      # Select Docker Hub credentials based on PHP version (rotate between 4 accounts)
+      - name: Select Docker Hub credentials
+        id: docker-creds
+        run: |
+          case "${{ matrix.php }}" in
+            "7.4") KEY_NUM=1 ;;
+            "8.1") KEY_NUM=2 ;;
+            "8.2") KEY_NUM=3 ;;
+            "8.3") KEY_NUM=4 ;;
+            "8.4") KEY_NUM=1 ;;
+            "8.5") KEY_NUM=2 ;;
+            *) KEY_NUM=1 ;;
+          esac
+          echo "key_num=${KEY_NUM}" >> $GITHUB_OUTPUT
+          echo "[INFO] Using Docker Hub credentials set #${KEY_NUM} for PHP ${{ matrix.php }}"
+      
       # Login to Docker Hub (optional, increases rate limit from 100 to 200 pulls/6h)
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets[format('DOCKERHUB_USERNAME_{0}', steps.docker-creds.outputs.key_num)] }}
+          password: ${{ secrets[format('DOCKERHUB_TOKEN_{0}', steps.docker-creds.outputs.key_num)] }}
         continue-on-error: true
       
       - name: Log in to GHCR
@@ -463,12 +493,28 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
-      # Login to Docker Hub
+      # Select Docker Hub credentials based on PHP version (rotate between 4 accounts)
+      - name: Select Docker Hub credentials
+        id: docker-creds
+        run: |
+          case "${{ matrix.php }}" in
+            "7.4") KEY_NUM=1 ;;
+            "8.1") KEY_NUM=2 ;;
+            "8.2") KEY_NUM=3 ;;
+            "8.3") KEY_NUM=4 ;;
+            "8.4") KEY_NUM=1 ;;
+            "8.5") KEY_NUM=2 ;;
+            *) KEY_NUM=1 ;;
+          esac
+          echo "key_num=${KEY_NUM}" >> $GITHUB_OUTPUT
+          echo "[INFO] Using Docker Hub credentials set #${KEY_NUM} for PHP ${{ matrix.php }}"
+      
+      # Login to Docker Hub (optional, increases rate limit from 100 to 200 pulls/6h)
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets[format('DOCKERHUB_USERNAME_{0}', steps.docker-creds.outputs.key_num)] }}
+          password: ${{ secrets[format('DOCKERHUB_TOKEN_{0}', steps.docker-creds.outputs.key_num)] }}
         continue-on-error: true
       
       - name: Log in to GHCR

--- a/Formula/docker-compose-oroplatform.rb
+++ b/Formula/docker-compose-oroplatform.rb
@@ -2,7 +2,7 @@ class DockerComposeOroplatform < Formula
   desc "CLI tool to run ORO applications locally or on a server"
   homepage "https://github.com/digitalspacestdio/homebrew-docker-compose-oroplatform"
   url "file:///dev/null"
-  version "0.11.49"
+  version "0.11.50"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
   def self.aliases


### PR DESCRIPTION
- Rotate between 4 Docker Hub accounts based on PHP version
- PHP 7.4, 8.4 use account 1
- PHP 8.1, 8.5 use account 2
- PHP 8.2 uses account 3
- PHP 8.3 uses account 4
- Increases total rate limit from 200 to 800 pulls/6h
- Requires 8 GitHub secrets: DOCKERHUB_USERNAME_1-4 and DOCKERHUB_TOKEN_1-4
- Version bump: 0.11.49 -> 0.11.50