### PR TITLE
fix: bump pnpm for node 24 image

### DIFF
--- a/Formula/docker-compose-oroplatform.rb
+++ b/Formula/docker-compose-oroplatform.rb
@@ -2,7 +2,7 @@ class DockerComposeOroplatform < Formula
   desc "CLI tool to run ORO applications locally or on a server"
   homepage "https://github.com/digitalspacestdio/homebrew-docker-compose-oroplatform"
   url "file:///dev/null"
-  version "1.3.19"
+  version "1.3.20"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
   def self.aliases

--- a/compose/docker/php-node-symfony/8.5/Dockerfile
+++ b/compose/docker/php-node-symfony/8.5/Dockerfile
@@ -58,6 +58,8 @@ RUN rm -f /usr/local/bin/yarn /usr/local/bin/yarnpkg /usr/local/bin/pnpm /usr/lo
     && npm install -g yarn@1.22.22 \
     && case "${NODE_VERSION}" in \
       14*|16*) node --version && npm --version && yarn --version ;; \
+      24*) npm install -g pnpm@10.32.0 \
+         && node --version && npm --version && yarn --version && pnpm --version ;; \
       *) npm install -g pnpm@9.15.9 \
          && node --version && npm --version && yarn --version && pnpm --version ;; \
     esac


### PR DESCRIPTION
Install pnpm 10.32.0 only for the PHP 8.5 Node 24 image so lockfile generation works with projects that now require pnpm 10+.