### PR TITLE
fix: check quiet-pull/quiet-build support before passing to docker compose up

### DIFF
--- a/Formula/docker-compose-oroplatform.rb
+++ b/Formula/docker-compose-oroplatform.rb
@@ -2,7 +2,7 @@ class DockerComposeOroplatform < Formula
   desc "CLI tool to run ORO applications locally or on a server"
   homepage "https://github.com/digitalspacestdio/homebrew-docker-compose-oroplatform"
   url "file:///dev/null"
-  version "1.3.20"
+  version "1.3.21"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
   def self.aliases

--- a/libexec/orodc/lib/docker-utils.sh
+++ b/libexec/orodc/lib/docker-utils.sh
@@ -319,10 +319,15 @@ handle_compose_up() {
     up_flags+=("--wait")
   fi
 
-  # Add quiet flags to suppress output when running with spinner
-  # This ensures spinner is visible and not overwritten by docker compose output
+  # Add quiet flags only if current docker compose supports them.
+  # Some compose versions (e.g. v5.x) do not support --quiet-build for `up`.
+  # shellcheck disable=SC2154
+  up_help=$(${DOCKER_COMPOSE_BIN_CMD} up --help 2>/dev/null || true)
+
   has_quiet_pull=false
   has_quiet_build=false
+  supports_quiet_pull=false
+  supports_quiet_build=false
   for flag in "${up_flags[@]}"
   do
     if [[ "${flag}" == "--quiet-pull" ]]
@@ -335,13 +340,22 @@ handle_compose_up() {
     fi
   done
 
-  # Add quiet flags if not already present (only when running with spinner, not in verbose mode)
+  if echo "${up_help}" | grep -q -- "--quiet-pull"
+  then
+    supports_quiet_pull=true
+  fi
+  if echo "${up_help}" | grep -q -- "--quiet-build"
+  then
+    supports_quiet_build=true
+  fi
+
+  # Add supported quiet flags if not already present.
   quiet_flags=()
-  if [[ "${has_quiet_pull}" == "false" ]]
+  if [[ "${has_quiet_pull}" == "false" ]] && [[ "${supports_quiet_pull}" == "true" ]]
   then
     quiet_flags+=("--quiet-pull")
   fi
-  if [[ "${has_quiet_build}" == "false" ]]
+  if [[ "${has_quiet_build}" == "false" ]] && [[ "${supports_quiet_build}" == "true" ]]
   then
     quiet_flags+=("--quiet-build")
   fi


### PR DESCRIPTION
## Summary
- Detect whether the current `docker compose` version supports `--quiet-pull` and `--quiet-build` flags before adding them to `up` command
- Prevents errors on compose versions (e.g. v5.x) that removed or never had these flags

## Changes
- `libexec/orodc/lib/docker-utils.sh`: parse `docker compose up --help` output to check flag availability
- Bump version to 1.3.21

Made with [Cursor](https://cursor.com)