### PR TITLE
fix: preserve PostgreSQL data volume layout

### DIFF
--- a/Formula/docker-compose-oroplatform.rb
+++ b/Formula/docker-compose-oroplatform.rb
@@ -2,7 +2,7 @@ class DockerComposeOroplatform < Formula
   desc "CLI tool to run ORO applications locally or on a server"
   homepage "https://github.com/digitalspacestdio/homebrew-docker-compose-oroplatform"
   url "file:///dev/null"
-  version "1.3.25"
+  version "1.3.26"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
   def self.aliases

--- a/compose/docker-compose-pgsql.yml
+++ b/compose/docker-compose-pgsql.yml
@@ -15,7 +15,7 @@ services:
       POSTGRES_DB: '${DC_ORO_DATABASE_DBNAME:-oro_db}'
     volumes:
       - '${DC_ORO_CONFIG_DIR}/docker/pgsql/initdb.d:/docker-entrypoint-initdb.d:ro'
-      - 'postgresql-data:/var/lib/postgresql/data:delegated'
+      - 'postgresql-data:${DC_ORO_PGSQL_DATA_VOLUME_TARGET:-/var/lib/postgresql}:delegated'
     ports:
       - '${DC_ORO_DATABASE_BIND_HOST:-127.0.0.1}:${DC_ORO_PORT_PGSQL:-5432}:5432'
     restart: always

--- a/libexec/orodc/init.sh
+++ b/libexec/orodc/init.sh
@@ -852,6 +852,12 @@ EOF
   elif [[ "${SELECTED_DB_SCHEMA}" == "pgsql" ]]
   then
     update_env_var "${TARGET_ENV_FILE}" "DC_ORO_PGSQL_VERSION" "${SELECTED_DB_VERSION}"
+    if [[ "${SELECTED_DB_VERSION%%.*}" -ge 18 ]]
+    then
+      update_env_var "${TARGET_ENV_FILE}" "DC_ORO_PGSQL_DATA_VOLUME_TARGET" "/var/lib/postgresql"
+    else
+      update_env_var "${TARGET_ENV_FILE}" "DC_ORO_PGSQL_DATA_VOLUME_TARGET" "/var/lib/postgresql/data"
+    fi
   fi
 
   # Search Engine Configuration

--- a/libexec/orodc/lib/environment.sh
+++ b/libexec/orodc/lib/environment.sh
@@ -726,10 +726,23 @@ initialize_environment() {
       debug_log "initialize_environment: derived DC_ORO_MYSQL_IMAGE from DC_ORO_DATABASE_IMAGE (backward compat)"
     fi
     # PostgreSQL: Backward compat - derive DC_ORO_PGSQL_VERSION from DC_ORO_DATABASE_* (compose uses PGSQL_ vars)
-    if [[ "${DC_ORO_DATABASE_SCHEMA:-}" == "pgsql" ]] && [[ -z "${DC_ORO_PGSQL_VERSION:-}" ]] && [[ -n "${DC_ORO_DATABASE_VERSION:-}" ]]
+    if [[ "${DC_ORO_DATABASE_SCHEMA:-}" =~ ^(pgsql|postgres|postgresql|pdo_pgsql)$ ]] && [[ -z "${DC_ORO_PGSQL_VERSION:-}" ]] && [[ -n "${DC_ORO_DATABASE_VERSION:-}" ]]
     then
       export DC_ORO_PGSQL_VERSION="${DC_ORO_DATABASE_VERSION}"
       debug_log "initialize_environment: derived DC_ORO_PGSQL_VERSION from DC_ORO_DATABASE_VERSION (backward compat)"
+    fi
+    if [[ "${DC_ORO_DATABASE_SCHEMA:-}" =~ ^(pgsql|postgres|postgresql|pdo_pgsql)$ ]] && [[ -z "${DC_ORO_PGSQL_DATA_VOLUME_TARGET:-}" ]]
+    then
+      local pgsql_major
+      pgsql_major="${DC_ORO_PGSQL_VERSION:-${DC_ORO_DATABASE_VERSION:-18.4}}"
+      pgsql_major="${pgsql_major%%.*}"
+      if [[ "${pgsql_major}" -ge 18 ]]
+      then
+        export DC_ORO_PGSQL_DATA_VOLUME_TARGET="/var/lib/postgresql"
+      else
+        export DC_ORO_PGSQL_DATA_VOLUME_TARGET="/var/lib/postgresql/data"
+      fi
+      debug_log "initialize_environment: DC_ORO_PGSQL_DATA_VOLUME_TARGET=${DC_ORO_PGSQL_DATA_VOLUME_TARGET}"
     fi
     # MySQL: Select config file by version (my-5.7.cnf for <8, my-8.cnf for 8+)
     if [[ "${DC_ORO_DATABASE_SCHEMA:-}" == "mysql" ]] && [[ -z "${DC_ORO_MYSQL_CONF:-}" ]]


### PR DESCRIPTION
Select the PostgreSQL data volume mount path by major version so PostgreSQL 18 uses the new image layout without breaking existing PostgreSQL 15-17 projects.