### PR TITLE
fix: trust forwarded headers from host Traefik on proxy web entrypoint

### DIFF
--- a/Formula/docker-compose-oroplatform.rb
+++ b/Formula/docker-compose-oroplatform.rb
@@ -2,7 +2,7 @@ class DockerComposeOroplatform < Formula
   desc "CLI tool to run ORO applications locally or on a server"
   homepage "https://github.com/digitalspacestdio/homebrew-docker-compose-oroplatform"
   url "file:///dev/null"
-  version "1.3.27"
+  version "1.3.28"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
   def self.aliases

--- a/compose/docker/proxy/traefik.yml
+++ b/compose/docker/proxy/traefik.yml
@@ -7,6 +7,16 @@ global:
 entryPoints:
   web:
     address: ":80"
+    # Trust X-Forwarded-* from host Traefik (macOS dual-proxy setup).
+    # Host Traefik terminates TLS and forwards HTTP to :8880 with
+    # X-Forwarded-Proto: https; without this, Traefik overwrites it to http
+    # and Symfony/Oro redirects to HTTPS in an infinite loop.
+    forwardedHeaders:
+      trustedIPs:
+        - "127.0.0.1/32"
+        - "172.0.0.0/8"
+        - "10.0.0.0/8"
+        - "192.168.0.0/16"
     # Optional: HTTP to HTTPS redirect (commented out by default)
     # http:
     #   redirections:


### PR DESCRIPTION
Host Traefik terminates TLS and forwards HTTP to Docker Traefik :8880; without trustedIPs the X-Forwarded-Proto header is overwritten to http, causing infinite HTTPS redirect loops for Oro/Symfony apps on macOS.