### PR TITLE
Fix proxy DNS sync restart loop with Docker CLI 29.x

### DIFF
--- a/Formula/docker-compose-oroplatform.rb
+++ b/Formula/docker-compose-oroplatform.rb
@@ -2,7 +2,7 @@ class DockerComposeOroplatform < Formula
   desc "CLI tool to run ORO applications locally or on a server"
   homepage "https://github.com/digitalspacestdio/homebrew-docker-compose-oroplatform"
   url "file:///dev/null"
-  version "1.3.31"
+  version "1.3.32"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
   def self.aliases

--- a/compose/docker/proxy/dns-sync.sh
+++ b/compose/docker/proxy/dns-sync.sh
@@ -175,7 +175,7 @@ main() {
     # Use docker CLI if available
     docker events --filter 'type=container' --filter 'event=start' \
       --filter 'event=stop' --filter 'event=die' \
-      --format '{{.Status}}' 2>/dev/null | while read -r event; do
+      --format '{{.Action}}' | while read -r event; do
       log "Event: ${event}"
       update_hosts
     done


### PR DESCRIPTION
docker events no longer exposes .Status on events.Message; use .Action so dns-sync stays running instead of exiting and being restarted by s6.