### PR TITLE
fix(ci): store orodc config outside workspace on self-hosted runners

### DIFF
--- a/.github/workflows/test-oro-installations-containerized.yml
+++ b/.github/workflows/test-oro-installations-containerized.yml
@@ -228,12 +228,12 @@ jobs:
             export DC_ORO_NAME="${UNIQUE_PROJECT_NAME}"
             export DC_ORO_PORT_PREFIX="${PORT_PREFIX}"
             export DC_ORO_MODE=default
-            export DC_ORO_CONFIG_DIR="${TEST_BASE_DIR}/.orodc/${UNIQUE_PROJECT_NAME}"
+            # Container-local path avoids bind-mount permission issues on self-hosted runners
+            export DC_ORO_CONFIG_DIR="/home/runner/.orodc/${UNIQUE_PROJECT_NAME}"
             
-            # Keep OroDC config inside the workspace for writable CI mounts and runner access
-            mkdir -p "${DC_ORO_CONFIG_DIR}"
-            chown -R 1000:1000 "${DC_ORO_CONFIG_DIR}"
-            chmod -R 755 "${DC_ORO_CONFIG_DIR}"
+            # Create config and SSH key as runner (root chown on workspace mount is unreliable on ARM64)
+            su - runner -c "mkdir -p '${DC_ORO_CONFIG_DIR}' && chmod 700 '${DC_ORO_CONFIG_DIR}'"
+            su - runner -c "[[ -f '${DC_ORO_CONFIG_DIR}/ssh_id_ed25519' ]] || ssh-keygen -t ed25519 -f '${DC_ORO_CONFIG_DIR}/ssh_id_ed25519' -N '' -q"
             
             # Cleanup Docker networks
             docker network prune -f 2>/dev/null || true
@@ -300,6 +300,7 @@ jobs:
           RUN_SHORT=$(echo "${{ github.run_id }}" | tail -c 6)
           cd ${{ github.workspace }}
           rm -rf test-${RUN_SHORT}-* 2>/dev/null || true
+          rm -rf /home/runner/.orodc/${{ matrix.application.name }}-${RUN_SHORT}-* 2>/dev/null || true
           
           # Cleanup Docker containers and volumes by build ID pattern
           echo "🐳 Cleaning up Docker containers for build ${{ github.run_id }}..."


### PR DESCRIPTION
Move DC_ORO_CONFIG_DIR to /home/runner/.orodc and create SSH keys as the runner user so ARM64 bind mounts do not block ssh-keygen with permission denied.