### PR TITLE
Remove nonexistent Traefik cert resolver from HTTPS entrypoint.

### DIFF
--- a/Formula/docker-compose-oroplatform.rb
+++ b/Formula/docker-compose-oroplatform.rb
@@ -2,7 +2,7 @@ class DockerComposeOroplatform < Formula
   desc "CLI tool to run ORO applications locally or on a server"
   homepage "https://github.com/digitalspacestdio/homebrew-docker-compose-oroplatform"
   url "file:///dev/null"
-  version "1.3.32"
+  version "1.3.33"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
   def self.aliases

--- a/compose/docker/proxy/traefik.yml
+++ b/compose/docker/proxy/traefik.yml
@@ -26,9 +26,6 @@ entryPoints:
   
   default:
     address: ":443"
-    http:
-      tls:
-        certResolver: default
 
 # API and Dashboard
 api:


### PR DESCRIPTION
Routers on :443 were inheriting certResolver=default without a certificatesResolvers block; static *.docker.local TLS from dynamic.yml is sufficient.