### PR TITLE
fix: remove SSH resolv.conf override that broke container DNS

### DIFF
--- a/Formula/docker-compose-oroplatform.rb
+++ b/Formula/docker-compose-oroplatform.rb
@@ -2,7 +2,7 @@ class DockerComposeOroplatform < Formula
   desc "CLI tool to run ORO applications locally or on a server"
   homepage "https://github.com/digitalspacestdio/homebrew-docker-compose-oroplatform"
   url "file:///dev/null"
-  version "1.3.33"
+  version "1.3.34"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
   def self.aliases

--- a/compose/docker/php-node-symfony/shared/docker-sshd.sh
+++ b/compose/docker/php-node-symfony/shared/docker-sshd.sh
@@ -1,17 +1,5 @@
 #!/bin/bash
 set -x
-
-configure_dns() {
-	local resolv_conf="/etc/resolv.conf"
-	[[ -w "${resolv_conf}" ]] || return 0
-
-	cat > "${resolv_conf}" <<'EOF'
-nameserver 1.1.1.1
-nameserver 8.8.8.8
-EOF
-}
-configure_dns
-
 if [[ -f /etc/ssh/sshd_config.backup ]]; then
 	cp /etc/ssh/sshd_config.backup /etc/ssh/sshd_config
 else


### PR DESCRIPTION
Overwriting /etc/resolv.conf dropped Docker embedded DNS (127.0.0.11), so service names like database and redis stopped resolving in SSH containers.